### PR TITLE
fix update button state

### DIFF
--- a/Classes/BITUpdateViewController.m
+++ b/Classes/BITUpdateViewController.m
@@ -209,6 +209,14 @@
         
     _cells = [[NSMutableArray alloc] initWithCapacity:5];
     _popOverController = nil;
+    
+    //might be better in viewDidLoad, but to workaround rdar://12214613 and as it doesn't
+    //hurt, we do it here
+    if (self.modal) {
+      self.navigationItem.leftBarButtonItem = [[[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone
+                                                                                             target:self
+                                                                                             action:@selector(onAction:)] autorelease];
+    }
   }
   return self;
 }
@@ -355,12 +363,6 @@
   }
   
   self.tableView.tableHeaderView = _appStoreHeader;
-  
-  if (self.modal) {
-    self.navigationItem.leftBarButtonItem = [[[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone
-                                                                                           target:self
-                                                                                           action:@selector(onAction:)] autorelease];
-  }
   
   PSStoreButton *storeButton = [[[PSStoreButton alloc] initWithPadding:CGPointMake(5, 40)] autorelease];
   storeButton.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin;


### PR DESCRIPTION
if the user has UINavigationButton's text attributes customized
iOS 6 beta 4 calls viewWillAppear if a navigationButton is set
on the navigationItem in viewDidLoad (rdar://12214613)
As BITUpdateViewController thinks the view was already loaded
in viewWillAppear, the button state is not properly set.

Setting the navigationButton in init fixes this.

(seems I can't add PRs from my old codenauts fork anymore)
