### PR TITLE
Update podspec in preparation of 2.5.3

### DIFF
--- a/HockeySDK.podspec
+++ b/HockeySDK.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.name     = 'HockeySDK'
-  s.version  = '2.5.1'
+  s.version  = '2.5.3'
   s.license  = 'MIT'
   s.platform = :ios, '4.0'
   s.summary  = 'Distribute beta apps and collect crash reports with HockeyApp.'
   s.homepage = 'http://hockeyapp.net/'
   s.author   = { 'Andreas Linde' => 'mail@andreaslinde.de', 'Thomas Dohmke' => "thomas@dohmke.de" }
-  s.source   = { :git => 'https://github.com/bitstadium/HockeySDK-iOS.git', :tag => '2.5.1' }
+  s.source   = { :git => 'https://github.com/bitstadium/HockeySDK-iOS.git', :tag => '2.5.3' }
 
   s.description = 'HockeyApp is a server to distribute beta apps and collect crash reports. '                   \
                   'It improves the testing process dramatically and can be used for both beta '                 \


### PR DESCRIPTION
I’ve also pushed a spec for 2.5.2 to the CocoaPods spec repo: https://github.com/CocoaPods/Specs/commit/feafed18a8b619e24bdcc9848fb0fc413ed376da.
