### PR TITLE
Added a forward declaration of BITCrashManager in BITCrashManagerDelegat...

### DIFF
--- a/Classes/BITCrashManagerDelegate.h
+++ b/Classes/BITCrashManagerDelegate.h
@@ -28,6 +28,8 @@
 
 #import <Foundation/Foundation.h>
 
+@class BITCrashManager;
+
 /**
  The `BITCrashManagerDelegate` formal protocol defines methods further configuring
  the behaviour of `BITCrashManager`.


### PR DESCRIPTION
I was getting compile errors when using HockeySDK through CocoaPods without this forward declaration unless I imported BITCrashManager before importing the delegate protocol. This seemed like the easiest way to solve this problem.
