### PR TITLE
cleanup JIRA_MOBILE_CONNECT_SUPPORT_ENABLED defines

### DIFF
--- a/Classes/BITHockeyManager.m
+++ b/Classes/BITHockeyManager.m
@@ -38,7 +38,7 @@
 
 - (BOOL)shouldUseLiveIdentifier;
 
-#if defined(JIRA_MOBILE_CONNECT_SUPPORT_ENABLED) && JIRA_MOBILE_CONNECT_SUPPORT_ENABLED
+#if JIRA_MOBILE_CONNECT_SUPPORT_ENABLED
 - (void)configureJMC;
 #endif
 
@@ -172,7 +172,7 @@
   
   // Setup UpdateManager
   if (![self isUpdateManagerDisabled]
-#if defined(JIRA_MOBILE_CONNECT_SUPPORT_ENABLED) && JIRA_MOBILE_CONNECT_SUPPORT_ENABLED
+#if JIRA_MOBILE_CONNECT_SUPPORT_ENABLED
       || [[self class] isJMCPresent]
 #endif
       ) {
@@ -240,7 +240,7 @@
     _updateManager = [[BITUpdateManager alloc] initWithAppIdentifier:_appIdentifier isAppStoreEnvironemt:_appStoreEnvironment];
     _updateManager.delegate = _delegate;
     
-#if defined(JIRA_MOBILE_CONNECT_SUPPORT_ENABLED) && JIRA_MOBILE_CONNECT_SUPPORT_ENABLED
+#if JIRA_MOBILE_CONNECT_SUPPORT_ENABLED
     // Only if JMC is part of the project
     if ([[self class] isJMCPresent]) {
       BITHockeyLog(@"INFO: Setup JMC");
@@ -256,7 +256,7 @@
   }
 }
 
-#if defined(JIRA_MOBILE_CONNECT_SUPPORT_ENABLED) && JIRA_MOBILE_CONNECT_SUPPORT_ENABLED
+#if JIRA_MOBILE_CONNECT_SUPPORT_ENABLED
 
 #pragma mark - JMC
 

--- a/Classes/HockeySDKPrivate.h
+++ b/Classes/HockeySDKPrivate.h
@@ -50,8 +50,11 @@
 #define BITHOCKEYSDK_BUNDLE @"HockeySDKResources.bundle"
 #define BITHOCKEYSDK_URL @"https://sdk.hockeyapp.net/"
 
-/* Whether to compile in support for Jira Mobile Connect */
-#define JIRA_MOBILE_CONNECT_SUPPORT_ENABLED 0
+// Whether to compile in support for Jira Mobile Connect
+// default is disabled
+#ifndef JIRA_MOBILE_CONNECT_SUPPORT_ENABLED
+  #define JIRA_MOBILE_CONNECT_SUPPORT_ENABLED 0
+#endif
 
 #define BITHockeyLog(fmt, ...) do { if([BITHockeyManager sharedHockeyManager].isDebugLogEnabled && ![BITHockeyManager sharedHockeyManager].isAppStoreEnvironment) { NSLog((@"[HockeySDK] %s/%d " fmt), __PRETTY_FUNCTION__, __LINE__, ##__VA_ARGS__); }} while(0)
 


### PR DESCRIPTION
- only define JIRA_MOBILE_CONNECT_SUPPORT_ENABLED if it's not already defined.
  default is disabled
- cleanup usage of JIRA_MOBILE_CONNECT_SUPPORT_ENABLED
  it's always defined, so no need to check
