### PR TITLE
Suppress Xcode 4.6 static analyzer unused variable warning in external variables.

### DIFF
--- a/Classes/BITCrashManager.h
+++ b/Classes/BITCrashManager.h
@@ -36,7 +36,7 @@ typedef enum {
   BITCrashManagerStatusAlwaysAsk = 1,
   BITCrashManagerStatusAutoSend = 2
 } BITCrashManagerStatus;
-extern NSString *const kBITCrashManagerStatus;
+extern NSString *const __attribute__((unused)) kBITCrashManagerStatus;
 
 
 @protocol BITCrashManagerDelegate;

--- a/Classes/HockeySDK.h
+++ b/Classes/HockeySDK.h
@@ -52,7 +52,7 @@ typedef enum {
   BITCrashAPIReceivedEmptyResponse,
   BITCrashAPIErrorWithStatusCode
 } BITCrashErrorReason;
-extern NSString *const kBITCrashErrorDomain;
+extern NSString *const __attribute__((unused)) kBITCrashErrorDomain;
 
 // Update App Versions
 
@@ -65,7 +65,7 @@ typedef enum {
   BITUpdateAPIClientAuthorizationMissingSecret,
   BITUpdateAPIClientCannotCreateConnection
 } BITUpdateErrorReason;
-extern NSString *const kBITUpdateErrorDomain;
+extern NSString *const __attribute__((unused)) kBITUpdateErrorDomain;
 
 
 #endif


### PR DESCRIPTION
Added `__attribute__((unused))` to a few properties to suppress unused warning in external variable definitions in Xcode 4.6
