### PR TITLE
Suppress unused warnings from Static analizer

### DIFF
--- a/Classes/HockeySDK.h
+++ b/Classes/HockeySDK.h
@@ -58,7 +58,7 @@ typedef enum {
   BITCrashAPIReceivedEmptyResponse,
   BITCrashAPIErrorWithStatusCode
 } BITCrashErrorReason;
-extern NSString *const kBITCrashErrorDomain;
+extern NSString *const __attribute__((unused)) kBITCrashErrorDomain;
 
 // Update App Versions
 
@@ -71,7 +71,7 @@ typedef enum {
   BITUpdateAPIClientAuthorizationMissingSecret,
   BITUpdateAPIClientCannotCreateConnection
 } BITUpdateErrorReason;
-extern NSString *const kBITUpdateErrorDomain;
+extern NSString *const __attribute__((unused)) kBITUpdateErrorDomain;
 
 
 // Update App Versions
@@ -85,7 +85,7 @@ typedef enum {
   BITFeedbackAPIClientAuthorizationMissingSecret,
   BITFeedbackAPIClientCannotCreateConnection
 } BITFeedbackErrorReason;
-extern NSString *const kBITFeedbackErrorDomain;
+extern NSString *const __attribute__((unused)) kBITFeedbackErrorDomain;
 
 
 // HockeySDK
@@ -95,7 +95,7 @@ typedef enum {
   BITHockeyErrorUnknown,
   HockeyAPIClientMissingJSONLibrary
 } BITHockeyErrorReason;
-extern NSString *const kBITHockeyErrorDomain;
+extern NSString *const __attribute__((unused)) kBITHockeyErrorDomain;
 
 
 #endif


### PR DESCRIPTION
Added `__attribute__((unused))` to a few properties to suppress unused warning in external variable definitions in Xcode 4.6

Same stuff from #27 just now in develop.

https://github.com/bitstadium/HockeySDK-iOS/pull/27
