### PR TITLE
fixed warning "dismissModalViewControllerAnimated is deprecated"

### DIFF
--- a/Classes/BITFeedbackComposeViewController.m
+++ b/Classes/BITFeedbackComposeViewController.m
@@ -222,7 +222,7 @@
   if (self.delegate && [self.delegate respondsToSelector:@selector(feedbackComposeViewControllerDidFinish:)]) {
     [self.delegate feedbackComposeViewControllerDidFinish:self];
   } else {
-    [self dismissModalViewControllerAnimated:YES];
+    [self dismissViewControllerAnimated:YES completion:nil];
   }
 }
 
@@ -263,21 +263,21 @@
     if ([self.navigationController respondsToSelector:@selector(dismissViewControllerAnimated:completion:)]) {
       [self.navigationController dismissViewControllerAnimated:YES
                                                     completion:^(void) {
-                                                      [self dismissModalViewControllerAnimated:YES];
+                                                      [self dismissViewControllerAnimated:YES completion:nil];
                                                     }];
     } else {
-      [self dismissModalViewControllerAnimated:YES];
+      [self dismissViewControllerAnimated:YES completion:nil];
       [self performSelector:@selector(dismissAction:) withObject:nil afterDelay:0.4];
     }
   } else {
-    [self.navigationController dismissModalViewControllerAnimated:YES];
+    [self.navigationController dismissViewControllerAnimated:YES completion:nil];
   }
 }
 
 - (void)userDataUpdateFinished {
   [self.manager saveMessages];
   
-  [self.navigationController dismissModalViewControllerAnimated:YES];
+  [self.navigationController dismissViewControllerAnimated:YES completion:nil];
 }
 
 

--- a/Classes/BITHockeyBaseViewController.m
+++ b/Classes/BITHockeyBaseViewController.m
@@ -50,7 +50,7 @@
     
     // If there is no presenting view controller just remove view
     if (presentingViewController && self.modalAnimated) {
-      [presentingViewController dismissModalViewControllerAnimated:YES];
+      [presentingViewController dismissViewControllerAnimated:YES completion:nil];
     } else {
       [self.navigationController.view removeFromSuperview];
     }


### PR DESCRIPTION
This warning is shown when compiling the SDK with deployment target 6.0.

This happens for example if you use cocoapods and set "platform :ios, '6.0'" in your Podfile.
