### PR TITLE
sync podspec to currently used xconfig and frameworks

### DIFF
--- a/HockeySDK.podspec
+++ b/HockeySDK.podspec
@@ -19,9 +19,10 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes'
   s.requires_arc = true
   s.preserve_paths = 'Resources', 'Support', 'Vendor'
-  s.frameworks   = 'CoreText', 'QuartzCore', 'SystemConfiguration', 'CrashReporter', 'CoreGraphics', 'UIKit'
+  s.frameworks   = 'CoreText', 'QuartzCore', 'SystemConfiguration', 'CrashReporter', 'CoreGraphics', 'UIKit', 'Security'
   s.xcconfig     = { 'FRAMEWORK_SEARCH_PATHS' => '"$(PODS_ROOT)/HockeySDK/Vendor"',
-                     'GCC_PREPROCESSOR_DEFINITIONS' => %{$(inherited) BITHOCKEY_VERSION="@\\"#{s.version}\\""} }
+                     'GCC_PREPROCESSOR_DEFINITIONS' => %{$(inherited) BITHOCKEY_VERSION="@\\"#{s.version}\\""}, 
+                     'HOCKEYSDK_DOCSET_NAME' => 'HockeySDK-iOS' }
 
   s.post_install do |library_representation|
     Dir.chdir File.join(library_representation.sandbox_dir, 'HockeySDK/Support') do


### PR DESCRIPTION
Leaving out 'CONFIGURATION_$(CONFIGURATION)' per http://support.hockeyapp.net/discussions/questions/2006-installingusing-hockeysdk-with-xcode-462-and-cocoapods#comment_26853492
