### PR TITLE
NSNotificationCenter notifications were not being cleaned up properly

### DIFF
--- a/Classes/BITFeedbackManager.m
+++ b/Classes/BITFeedbackManager.m
@@ -110,9 +110,7 @@
 }
 
 - (void)dealloc {
-  [[NSNotificationCenter defaultCenter] removeObserver:self name:BITHockeyNetworkDidBecomeReachableNotification object:nil];
-  
-  [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidBecomeActiveNotification object:nil];
+  [self cleanupDidBecomeActiveNotifications];
 }
 
 
@@ -149,6 +147,7 @@
 }
 
 - (void)cleanupDidBecomeActiveNotifications {
+  [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidEnterBackgroundNotification object:nil];
   [[NSNotificationCenter defaultCenter] removeObserver:self name:BITHockeyNetworkDidBecomeReachableNotification object:nil];
   [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidBecomeActiveNotification object:nil];
 }

--- a/Classes/BITUpdateManager.m
+++ b/Classes/BITUpdateManager.m
@@ -391,11 +391,10 @@ typedef NS_ENUM(NSInteger, BITUpdateAlertViewTag) {
 }
 
 - (void)dealloc {
-  [[NSNotificationCenter defaultCenter] removeObserver:self name:BITHockeyNetworkDidBecomeReachableNotification object:nil];
-  
   [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationWillTerminateNotification object:nil];
-  [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidBecomeActiveNotification object:nil];
   [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationWillResignActiveNotification object:nil];
+
+  [self cleanupDidBecomeActiveNotifications];
   
   [_urlConnection cancel];
 }


### PR DESCRIPTION
There are a few dangling `NSNotificationCenter` observers that are not cleaned up at deallocation. This caused our app to crash based on our setup where the user has to select an option in the app settings to enable private builds (we don't want our clients to see a HockeyApp popup when the app launches so we provide the separate option for QA). That implementation involves calling `[[BITHockeyManager sharedManager] startManager];` when they toggle the switch. 

The pull request is the minimal required to fix the problem. I highly recommend rejecting the pull request and instead using `[[NSNotificationCenter defaultCenter] removeObserver:self];` upon deallocation to ensure that all observers are removed. There are a number of inconsistencies throughout HockeySDK in whether `-dealloc` calls a different method to unregister notifications or performs the removal itself. My 2¢ is that it seems less problematic moving forward to remove all observers on dealloc in one fell swoop than to pair with each that was registered.
