### PR TITLE
Removed obsolete test

### DIFF
--- a/Support/HockeySDKTests/BITAuthenticatorTests.m
+++ b/Support/HockeySDKTests/BITAuthenticatorTests.m
@@ -300,16 +300,6 @@ static void *kInstallationIdentification = &kInstallationIdentification;
 }
 
 #pragma mark - Lifetime checks
-- (void) testThatAuthenticationTriggersOnStart {
-  id delegateMock = mockProtocol(@protocol(BITAuthenticatorDelegate));
-  _sut.delegate = delegateMock;
-  _sut.identificationType = BITAuthenticatorIdentificationTypeDevice;
-  
-  [_sut startManager];
-  
-  [verify(delegateMock) authenticator:_sut willShowAuthenticationController:(id)anything()];
-}
-
 - (void) testThatValidationTriggersOnDidBecomeActive {
   id delegateMock = mockProtocol(@protocol(BITAuthenticatorDelegate));
   _sut.delegate = delegateMock;


### PR DESCRIPTION
The user is now required to call `authenticateInstallation` manually, which obviates the need for this test.

Required call was implemented in 7052f0cd.
