### PR TITLE
Increase timeout interval to ensure updates occur

### DIFF
--- a/Classes/BITUpdateManager.m
+++ b/Classes/BITUpdateManager.m
@@ -710,7 +710,7 @@ typedef NS_ENUM(NSInteger, BITUpdateAlertViewTag) {
   NSString *url = [NSString stringWithFormat:@"%@%@", self.serverURL, parameter];
   BITHockeyLog(@"INFO: Sending api request to %@", url);
   
-  NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:url] cachePolicy:1 timeoutInterval:10.0];
+  NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:url] cachePolicy:1 timeoutInterval:60.0];
   [request setHTTPMethod:@"GET"];
   [request setValue:@"Hockey/iOS" forHTTPHeaderField:@"User-Agent"];
   [request setValue:@"gzip" forHTTPHeaderField:@"Accept-Encoding"];


### PR DESCRIPTION
I've found that timeouts often occur, since the query to the API is not parametrized up to 800 version objects might be downloaded at a slow speed if your app has a long history. This obviates the issue.