### PR TITLE
Backgrounded invokeDelayedProcessing

### DIFF
--- a/Classes/BITCrashManager.m
+++ b/Classes/BITCrashManager.m
@@ -704,7 +704,7 @@ NSString *const kBITCrashManagerStatus = @"BITCrashManagerStatus";
 
         dispatch_async(dispatch_get_main_queue(), ^{
           [alertView show];
-        })
+        });
 
       } else {
         [self sendCrashReports];


### PR DESCRIPTION
Doing this intensive method causes upwards of 3 full seconds of UI
freeze. There's nothing in there except presenting the `UIAlertView`
that needs to happen on the main thread. Wrapping most of the
function in a `dispatch_async` fixes a freeze on startup or wake
that our team had experienced a lot.
![screen shot 2014-05-03 at 10 55 26 pm](https://cloud.githubusercontent.com/assets/853032/2872086/b29c0cb0-d340-11e3-9b07-bdd93f2988cf.png)
