### PR TITLE
Fix missing call to super analyzer warning

### DIFF
--- a/Classes/BITImageAnnotationViewController.m
+++ b/Classes/BITImageAnnotationViewController.m
@@ -130,6 +130,7 @@ typedef NS_ENUM(NSInteger, BITImageAnnotationViewControllerInteractionMode) {
 }
 
 - (void)viewWillDisappear:(BOOL)animated {
+  [super viewWillDisappear:animated];
   [[NSNotificationCenter defaultCenter] removeObserver:self name:UIDeviceOrientationDidChangeNotification object:nil];
 
   [super viewWillDisappear:animated];


### PR DESCRIPTION
This is flagged up in Xcode 6's shallow analyzer check.
