### PR TITLE
Fix static analyzer warning

### DIFF
--- a/Classes/BITAttributedLabel.m
+++ b/Classes/BITAttributedLabel.m
@@ -957,41 +957,41 @@ static inline NSAttributedString * NSAttributedStringBySettingColorFromContext(N
 }
 
 - (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event {
-    if (self.activeLink) {
+    NSTextCheckingResult *activeLink = self.activeLink;
+    if (activeLink) {
         UITouch *touch = [touches anyObject];
-        if (self.activeLink == [self linkAtPoint:[touch locationInView:self]]) {
-            [self setLinkActive:NO withTextCheckingResult:self.activeLink];
+        if (activeLink == [self linkAtPoint:[touch locationInView:self]]) {
+            [self setLinkActive:NO withTextCheckingResult:activeLink];
             
             if (!self.delegate) {
                 return;
             }
             
-            NSTextCheckingResult *result = self.activeLink;
-            switch (result.resultType) {
+            switch (activeLink.resultType) {
                 case NSTextCheckingTypeLink:
                     if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithURL:)]) {
-                        [self.delegate attributedLabel:self didSelectLinkWithURL:result.URL];
+                        [self.delegate attributedLabel:self didSelectLinkWithURL:activeLink.URL];
                         return;
                     }
                     break;
                 case NSTextCheckingTypeAddress:
                     if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithAddress:)]) {
-                        [self.delegate attributedLabel:self didSelectLinkWithAddress:result.addressComponents];
+                        [self.delegate attributedLabel:self didSelectLinkWithAddress:activeLink.addressComponents];
                         return;
                     }
                     break;
                 case NSTextCheckingTypePhoneNumber:
                     if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithPhoneNumber:)]) {
-                        [self.delegate attributedLabel:self didSelectLinkWithPhoneNumber:result.phoneNumber];
+                        [self.delegate attributedLabel:self didSelectLinkWithPhoneNumber:activeLink.phoneNumber];
                         return;
                     }
                     break;
                 case NSTextCheckingTypeDate:
-                    if (result.timeZone && [self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithDate:timeZone:duration:)]) {
-                        [self.delegate attributedLabel:self didSelectLinkWithDate:result.date timeZone:result.timeZone duration:result.duration];
+                    if (activeLink.timeZone && [self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithDate:timeZone:duration:)]) {
+                        [self.delegate attributedLabel:self didSelectLinkWithDate:activeLink.date timeZone:activeLink.timeZone duration:activeLink.duration];
                         return;
                     } else if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithDate:)]) {
-                        [self.delegate attributedLabel:self didSelectLinkWithDate:result.date];
+                        [self.delegate attributedLabel:self didSelectLinkWithDate:activeLink.date];
                         return;
                     }
                     break;
@@ -1001,7 +1001,7 @@ static inline NSAttributedString * NSAttributedStringBySettingColorFromContext(N
             
             // Fallback to `attributedLabel:didSelectLinkWithTextCheckingResult:` if no other delegate method matched.
             if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithTextCheckingResult:)]) {
-                [self.delegate attributedLabel:self didSelectLinkWithTextCheckingResult:result];
+                [self.delegate attributedLabel:self didSelectLinkWithTextCheckingResult:activeLink];
             }
         }
     } else {


### PR DESCRIPTION
When compiling for the iOS simulator, it would produce this warning.

The receiver of message 'resultType' is nil and returns a value of type 'NSTextCheckingType' that will be garbage

```
    switch (result.resultType) {
            ~~~~~~ ^~~~~~~~~~
```
