### PR TITLE
Adds tintColor support to feedback list buttons

### DIFF
--- a/Classes/BITFeedbackListViewController.m
+++ b/Classes/BITFeedbackListViewController.m
@@ -514,7 +514,11 @@
     // button
     NSString *titleString = nil;
     SEL actionSelector = nil;
+    
     UIColor *titleColor = BIT_RGBCOLOR(35, 111, 251);
+    if ([self.view respondsToSelector:@selector(tintColor)]){
+      titleColor = self.view.tintColor;
+    }
     
     UIButton *button = nil;
     if ([self.manager isPreiOS7Environment]) {


### PR DESCRIPTION
## Issue
In my current project (deployment target: iOS 7) I need to customize the action button's (contained in BITFeedbackListViewController) textColor property to fit the design of the application. I couldn't figure out any solution to achieve this using the current implementation of the SDK.

## Solution contained in this pull request
For iOS 7 and above the buttons "Provide Feedback" (respectively "Write Response") and "Set Your Email" (respectively "Email: %@") will have the tableView's tintColor set as their textColor. If the tableView doesn't respond to the selector `tintColor`, the previous color (RGB: 35, 111, 251) will be used. 