### PR TITLE
Setting feedback composer initial items via BITFedbackManager

### DIFF
--- a/Classes/BITFeedbackManager.h
+++ b/Classes/BITFeedbackManager.h
@@ -222,6 +222,18 @@ typedef NS_ENUM(NSInteger, BITFeedbackObservationMode) {
 @property (nonatomic, readwrite) BITFeedbackObservationMode feedbackObservationMode;
 
 
+/**
+ Prefill feedback compose message user interface with the items given.
+ 
+ All NSString-Content in the array will be concatenated and result in the message,
+ while all UIImage and NSData-instances will be turned into attachments.
+ 
+ @param items an NSArray with objects that should be attached
+ @see `[BITFeedbackComposeViewController prepareWithItems:]`
+ */
+@property (nonatomic, copy) NSArray *feedbackComposerPreparedItems;
+
+
 ///-----------------------------------------------------------------------------
 /// @name User Interface
 ///-----------------------------------------------------------------------------

--- a/Classes/BITFeedbackManager.m
+++ b/Classes/BITFeedbackManager.m
@@ -224,6 +224,8 @@ NSString *const kBITFeedbackUpdateAttachmentThumbnail = @"BITFeedbackUpdateAttac
 
 - (BITFeedbackComposeViewController *)feedbackComposeViewController {
   BITFeedbackComposeViewController *composeViewController = [[BITFeedbackComposeViewController alloc] init];
+  [composeViewController prepareWithItems:self.feedbackComposerPreparedItems];
+    
   // by default set the delegate to be identical to the one of BITFeedbackManager
   [composeViewController setDelegate:self.delegate];
   return composeViewController;


### PR DESCRIPTION
The purpose of these changes is to add additional options to set `BITFeedbackComposeViewController` initial items using `BITFedbackManager`, because there is no way to configure `BITFeedbackComposeViewController` if user uses `BITFeedbackListViewController` to provide feedback.