### PR TITLE
Fix typos and spelling errors

### DIFF
--- a/Classes/BITAttributedLabel.m
+++ b/Classes/BITAttributedLabel.m
@@ -837,7 +837,7 @@ static inline NSAttributedString * NSAttributedStringBySettingColorFromContext(N
         
     NSAttributedString *originalAttributedText = nil;
     
-    // Adjust the font size to fit width, if necessarry 
+    // Adjust the font size to fit width, if necessary
     if (self.adjustsFontSizeToFitWidth && self.numberOfLines > 0) {
         CGFloat textWidth = [self sizeThatFits:CGSizeZero].width;
         CGFloat availableWidth = self.frame.size.width * self.numberOfLines;

--- a/Classes/BITAuthenticationViewController.h
+++ b/Classes/BITAuthenticationViewController.h
@@ -78,11 +78,11 @@
 /**
  *	called when the user wants to login
  *
- *	@param	viewController	the delegating viewcontroller
+ *	@param	viewController	the delegating view controller
  *	@param	email	the content of the email-field
  *	@param	password	the content of the password-field (if existent)
  *  @param  completion Must be called by the delegate once the auth-task completed
- *                     This viewcontroller shows an activity-indicator in between and blocks
+ *                     This view controller shows an activity-indicator in between and blocks
  *                     the UI. if succeeded is NO, it shows an alertView presenting the error
  *                     given by the completion block
  */

--- a/Classes/BITAuthenticator.h
+++ b/Classes/BITAuthenticator.h
@@ -221,7 +221,7 @@ typedef NS_ENUM(NSUInteger, BITAuthenticatorAppRestrictionEnforcementFrequency) 
 - (NSURL*) deviceAuthenticationURL;
 
 /**
- * The url-scheme used to idenfify via `BITAuthenticatorIdentificationTypeDevice`
+ * The url-scheme used to identify via `BITAuthenticatorIdentificationTypeDevice`
  *
  * Please make sure that the URL scheme is unique and not shared with other apps.
  *

--- a/Classes/BITCrashAttachment.h
+++ b/Classes/BITCrashAttachment.h
@@ -50,7 +50,7 @@
  @param crashAttachmentData The attachment data as NSData
  @param contentType         The content type of your data as MIME type
  
- @return An instsance of BITCrashAttachment
+ @return An instance of BITCrashAttachment
  */
 - (instancetype)initWithFilename:(NSString *)filename
              crashAttachmentData:(NSData *)crashAttachmentData

--- a/Classes/BITCrashAttachment.h
+++ b/Classes/BITCrashAttachment.h
@@ -31,7 +31,7 @@
 /**
  Deprecated: Provides support to add binary attachments to crash reports
  
- This class is not needed any longer and exists for compatiblity purposes with
+ This class is not needed any longer and exists for compatibility purposes with
  HockeySDK-iOS 3.5.5.
  
  It is a subclass of `BITHockeyAttachment` which only provides an initializer

--- a/Classes/BITCrashManager.h
+++ b/Classes/BITCrashManager.h
@@ -164,7 +164,7 @@ typedef NS_ENUM(NSUInteger, BITCrashManagerUserInput) {
 /** Set the default status of the Crash Manager
  
  Defines if the crash reporting feature should be disabled, ask the user before
- sending each crash report or send crash reportings automatically without
+ sending each crash report or send crash reports automatically without
  asking.
  
  The default value is `BITCrashManagerStatusAlwaysAsk`. The user can switch to
@@ -230,7 +230,7 @@ typedef NS_ENUM(NSUInteger, BITCrashManagerUserInput) {
  *  - The app tried to allocate too much memory. If iOS did send a memory warning before killing the app because of this reason, `didReceiveMemoryWarningInLastSession` returns `YES`.
  *  - Permitted background duration if main thread is running in an endless loop
  *  - App failed to resume in time if main thread is running in an endless loop
- *  - If `enableMachExceptionHandler` is not activated, crashed due to stackoverflow will also be reported
+ *  - If `enableMachExceptionHandler` is not activated, crashed due to stack overflow will also be reported
  *
  *  The following kills can _NOT_ be detected:
  *  - Terminating the app takes too long

--- a/Classes/BITCrashManager.h
+++ b/Classes/BITCrashManager.h
@@ -142,7 +142,7 @@ typedef NS_ENUM(NSUInteger, BITCrashManagerUserInput) {
  It is possible to check upon startup if the app crashed before using `didCrashInLastSession` and also how much
  time passed between the app launch and the crash using `timeintervalCrashInLastSessionOccured`. This allows you
  to add additional code to your app delaying the app start until the crash has been successfully send if the crash
- occured within a critical startup timeframe, e.g. after 10 seconds. The `BITCrashManagerDelegate` protocol provides
+ occurred within a critical startup timeframe, e.g. after 10 seconds. The `BITCrashManagerDelegate` protocol provides
  various delegates to inform the app about it's current status so you can continue the remaining app startup setup
  after sending has been completed. The documentation contains a guide
  [How to handle Crashes on startup](HowTo-Handle-Crashes-On-Startup) with an example on how to do that.

--- a/Classes/BITCrashManager.h
+++ b/Classes/BITCrashManager.h
@@ -74,7 +74,7 @@ typedef void (*BITCrashManagerPostCrashSignalCallback)(void *context);
 
 /**
  * This structure contains callbacks supported by `BITCrashManager` to allow the host application to perform
- * additional tasks prior to program termination after a crash has occured.
+ * additional tasks prior to program termination after a crash has occurred.
  *
  * @see `BITCrashManagerPostCrashSignalCallback`
  * @see `[BITCrashManager setCrashCallbacks:]`
@@ -244,7 +244,7 @@ typedef NS_ENUM(NSUInteger, BITCrashManagerUserInput) {
  *  The heuristic is implemented as follows:
  *  If the app never gets a `UIApplicationDidEnterBackgroundNotification` or `UIApplicationWillTerminateNotification`
  *  notification, PLCrashReporter doesn't detect a crash itself, and the app starts up again, it is assumed that
- *  the app got either killed by iOS while being in foreground or a crash occured that couldn't be detected.
+ *  the app got either killed by iOS while being in foreground or a crash occurred that couldn't be detected.
  *
  *  Default: _NO_
  *
@@ -356,7 +356,7 @@ typedef NS_ENUM(NSUInteger, BITCrashManagerUserInput) {
 - (void)setAlertViewHandler:(BITCustomAlertViewHandler)alertViewHandler;
 
 /**
- * Provides details about the crash that occured in the last app session
+ * Provides details about the crash that occurred in the last app session
  */
 @property (nonatomic, readonly) BITCrashDetails *lastSessionCrashDetails;
 

--- a/Classes/BITCrashManager.m
+++ b/Classes/BITCrashManager.m
@@ -349,14 +349,14 @@ static PLCrashReporterCallbacks plCrashCallbacks = {
 }
 
 /**
- *	 Extract all app sepcific UUIDs from the crash reports
+ *	 Extract all app specific UUIDs from the crash reports
  *
  * This allows us to send the UUIDs in the XML construct to the server, so the server does not need to parse the crash report for this data.
  * The app specific UUIDs help to identify which dSYMs are needed to symbolicate this crash report.
  *
  *	@param	report The crash report from PLCrashReporter
  *
- *	@return XML structure with the app sepcific UUIDs
+ *	@return XML structure with the app specific UUIDs
  */
 - (NSString *) extractAppUUIDs:(BITPLCrashReport *)report {
   NSMutableString *uuidString = [NSMutableString string];

--- a/Classes/BITCrashManager.m
+++ b/Classes/BITCrashManager.m
@@ -960,7 +960,7 @@ static PLCrashReporterCallbacks plCrashCallbacks = {
       NSString *appName = bit_appName(BITHockeyLocalizedString(@"HockeyAppNamePlaceholder"));
       NSString *alertDescription = [NSString stringWithFormat:BITHockeyLocalizedString(@"CrashDataFoundAnonymousDescription"), appName];
       
-      // the crash report is not anynomous any more if username or useremail are not nil
+      // the crash report is not anonymous any more if username or useremail are not nil
       NSString *userid = [self userIDForCrashReport];
       NSString *username = [self userNameForCrashReport];
       NSString *useremail = [self userEmailForCrashReport];

--- a/Classes/BITCrashReportTextFormatter.m
+++ b/Classes/BITCrashReportTextFormatter.m
@@ -422,7 +422,7 @@ static const char *findSEL (const char *imageName, NSString *imageUUID, uint64_t
     [text appendString: @"\n"];
   } else if (crashed_thread != nil) {
     // try to find the selector in case this was a crash in obj_msgSend
-    // we search this wether the crash happend in obj_msgSend or not since we don't have the symbol!
+    // we search this whether the crash happened in obj_msgSend or not since we don't have the symbol!
     
     NSString *foundSelector = nil;
 

--- a/Classes/BITCrashReportTextFormatter.m
+++ b/Classes/BITCrashReportTextFormatter.m
@@ -776,7 +776,7 @@ static const char *findSEL (const char *imageName, NSString *imageUUID, uint64_t
                             report: (BITPLCrashReport *) report
                               lp64: (BOOL) lp64
 {
-  /* Base image address containing instrumention pointer, offset of the IP from that base
+  /* Base image address containing instrumentation pointer, offset of the IP from that base
    * address, and the associated image name */
   uint64_t baseAddress = 0x0;
   uint64_t pcOffset = 0x0;

--- a/Classes/BITCrashReportTextFormatter.m
+++ b/Classes/BITCrashReportTextFormatter.m
@@ -207,7 +207,7 @@ static const char *findSEL (const char *imageName, NSString *imageUUID, uint64_t
   
 	/* Header */
 	
-  /* Map to apple style OS nane */
+  /* Map to apple style OS name */
   NSString *osName;
   switch (report.systemInfo.operatingSystem) {
     case PLCrashReportOperatingSystemMacOSX:

--- a/Classes/BITFeedbackComposeViewController.h
+++ b/Classes/BITFeedbackComposeViewController.h
@@ -35,7 +35,7 @@
  View controller allowing the user to write and send new feedback
  
  To add this view controller to your own app and push it onto a navigation stack,
- don't create the intance yourself, but use the following code to get a correct instance:
+ don't create the instance yourself, but use the following code to get a correct instance:
  
      [[BITHockeyManager sharedHockeyManager].feedbackManager feedbackComposeViewController]
  

--- a/Classes/BITFeedbackComposeViewController.h
+++ b/Classes/BITFeedbackComposeViewController.h
@@ -72,7 +72,7 @@
 /**
  An array of data objects that should be used to prefill the compose view content
  
- The follwoing data object classes are currently supported:
+ The following data object classes are currently supported:
  - NSString
  - NSURL
  - UIImage

--- a/Classes/BITFeedbackListViewController.h
+++ b/Classes/BITFeedbackListViewController.h
@@ -52,7 +52,7 @@
 
      [[BITHockeyManager sharedHockeyManager].feedbackManager feedbackListViewController:YES]
  
- This ensures that the presentation on iOS 6 and iOS 7 will use the corret design on each OS Version.
+ This ensures that the presentation on iOS 6 and iOS 7 will use the current design on each OS Version.
  */
 
 @interface BITFeedbackListViewController : BITHockeyBaseViewController <UITableViewDelegate, UITableViewDataSource, UIActionSheetDelegate, UIAlertViewDelegate, QLPreviewControllerDataSource> {

--- a/Classes/BITFeedbackListViewController.h
+++ b/Classes/BITFeedbackListViewController.h
@@ -44,7 +44,7 @@
  are allowed to be set.
  
  To add this view controller to your own app and push it onto a navigation stack,
- don't create the intance yourself, but use the following code to get a correct instance:
+ don't create the instance yourself, but use the following code to get a correct instance:
  
      [[BITHockeyManager sharedHockeyManager].feedbackManager feedbackListViewController:NO]
  

--- a/Classes/BITFeedbackListViewController.m
+++ b/Classes/BITFeedbackListViewController.m
@@ -303,7 +303,7 @@
 }
 
 - (UIView*) viewForShowingActionSheetOnPhone {
-  //find the topmost presented viewcontroller
+  //find the topmost presented view controller
   //and use its view
   UIViewController* topMostPresentedViewController = self.view.window.rootViewController;
   while(topMostPresentedViewController.presentedViewController) {

--- a/Classes/BITHockeyBaseManagerPrivate.h
+++ b/Classes/BITHockeyBaseManagerPrivate.h
@@ -49,7 +49,7 @@
 /** 
  * by default, just logs the message
  *
- * can be overriden by subclasses to do their own error handling,
+ * can be overridden by subclasses to do their own error handling,
  * e.g. to show UI
  *
  * @param error NSError

--- a/Classes/BITHockeyBaseManagerPrivate.h
+++ b/Classes/BITHockeyBaseManagerPrivate.h
@@ -59,7 +59,7 @@
 /** url encoded version of the appIdentifier
  
  where appIdentifier is either the value this object was initialized with,
- or the main bundles CFBundleIdentifier if appIdentifier ist nil
+ or the main bundles CFBundleIdentifier if appIdentifier is nil
  */
 - (NSString *)encodedAppIdentifier;
 

--- a/Classes/BITHockeyManagerDelegate.h
+++ b/Classes/BITHockeyManagerDelegate.h
@@ -126,7 +126,7 @@
  `BITFeedbackManager` uses it too for assigning the user to a discussion thread.
  
  In addition, if this returns not nil for `BITFeedbackManager` the user will
- not be asked for any user details by the component, including useerName or userEmail.
+ not be asked for any user details by the component, including userName or userEmail.
  
  You can find out the component requesting the userID like this:
  
@@ -162,7 +162,7 @@
  `BITFeedbackManager` uses it too for assigning the user to a discussion thread.
  
  In addition, if this returns not nil for `BITFeedbackManager` the user will
- not be asked for any user details by the component, including useerName or userEmail.
+ not be asked for any user details by the component, including userName or userEmail.
  
  You can find out the component requesting the user name like this:
  
@@ -198,7 +198,7 @@
  `BITFeedbackManager` uses it too for assigning the user to a discussion thread.
  
  In addition, if this returns not nil for `BITFeedbackManager` the user will
- not be asked for any user details by the component, including useerName or userEmail.
+ not be asked for any user details by the component, including userName or userEmail.
  
  You can find out the component requesting the user email like this:
  

--- a/Classes/BITKeychainUtils.h
+++ b/Classes/BITKeychainUtils.h
@@ -37,7 +37,7 @@
 + (NSString *) getPasswordForUsername: (NSString *) username andServiceName: (NSString *) serviceName error: (NSError **) error;
 //uses the default kSecAttrAccessibleWhenUnlocked
 + (BOOL) storeUsername: (NSString *) username andPassword: (NSString *) password forServiceName: (NSString *) serviceName updateExisting: (BOOL) updateExisting error: (NSError **) error;
-+ (BOOL) storeUsername: (NSString *) username andPassword: (NSString *) password forServiceName: (NSString *) serviceName updateExisting: (BOOL) updateExisting accessibility:(CFTypeRef) accessiblity error: (NSError **) error;
++ (BOOL) storeUsername: (NSString *) username andPassword: (NSString *) password forServiceName: (NSString *) serviceName updateExisting: (BOOL) updateExisting accessibility:(CFTypeRef) accessibility error: (NSError **) error;
 + (BOOL) deleteItemForUsername: (NSString *) username andServiceName: (NSString *) serviceName error: (NSError **) error;
 + (BOOL) purgeItemsForServiceName:(NSString *) serviceName error: (NSError **) error;
 

--- a/Classes/BITKeychainUtils.m
+++ b/Classes/BITKeychainUtils.m
@@ -126,7 +126,7 @@ static NSString *BITKeychainUtilsErrorDomain = @"BITKeychainUtilsErrorDomain";
   return [self storeUsername:username andPassword:password forServiceName:serviceName updateExisting:updateExisting accessibility:kSecAttrAccessibleWhenUnlocked error:error];
 }
 
-+ (BOOL) storeUsername: (NSString *) username andPassword: (NSString *) password forServiceName: (NSString *) serviceName updateExisting: (BOOL) updateExisting accessibility:(CFTypeRef) accessiblity error: (NSError **) error
++ (BOOL) storeUsername: (NSString *) username andPassword: (NSString *) password forServiceName: (NSString *) serviceName updateExisting: (BOOL) updateExisting accessibility:(CFTypeRef) accessibility error: (NSError **) error
 {
 	if (!username || !password || !serviceName)
   {
@@ -195,7 +195,7 @@ static NSString *BITKeychainUtilsErrorDomain = @"BITKeychainUtilsErrorDomain";
                           serviceName,
                           serviceName,
                           username,
-                          accessiblity,
+                          accessibility,
                           nil];
 			
 			NSDictionary *query = [[NSDictionary alloc] initWithObjects: objects forKeys: keys];
@@ -221,7 +221,7 @@ static NSString *BITKeychainUtilsErrorDomain = @"BITKeychainUtilsErrorDomain";
                         serviceName,
                         username,
                         [password dataUsingEncoding: NSUTF8StringEncoding],
-                        accessiblity,
+                        accessibility,
                         nil];
 		
 		NSDictionary *query = [[NSDictionary alloc] initWithObjects: objects forKeys: keys];

--- a/Classes/BITStoreUpdateManager.m
+++ b/Classes/BITStoreUpdateManager.m
@@ -210,9 +210,9 @@
     } else {
       BITHockeyLog(@"INFO: Compare new version string %@ with %@", _newStoreVersion, lastStoreVersion);
       
-      NSComparisonResult comparissonResult = bit_versionCompare(_newStoreVersion, lastStoreVersion);
+      NSComparisonResult comparisonResult = bit_versionCompare(_newStoreVersion, lastStoreVersion);
       
-      if (comparissonResult == NSOrderedDescending) {
+      if (comparisonResult == NSOrderedDescending) {
         return YES;
       } else {
         return NO;

--- a/Classes/BITUpdateManager.h
+++ b/Classes/BITUpdateManager.h
@@ -59,7 +59,7 @@ typedef NS_ENUM (NSUInteger, BITUpdateSetting) {
  The update manager module.
  
  This is the HockeySDK module for handling app updates when using Ad-Hoc or Enterprise provisioning profiles.
- This modul handles version updates, presents update and version information in a App Store like user interface,
+ This module handles version updates, presents update and version information in a App Store like user interface,
  collects usage information and provides additional authorization options when using Ad-Hoc provisioning profiles.
  
  This module automatically disables itself when running in an App Store build by default!

--- a/Classes/BITUpdateManager.m
+++ b/Classes/BITUpdateManager.m
@@ -333,11 +333,11 @@ typedef NS_ENUM(NSInteger, BITUpdateAlertViewTag) {
 
 - (void)checkUpdateAvailable {
   // check if there is an update available
-  NSComparisonResult comparissonResult = bit_versionCompare(self.newestAppVersion.version, self.currentAppVersion);
+  NSComparisonResult comparisonResult = bit_versionCompare(self.newestAppVersion.version, self.currentAppVersion);
   
-  if (comparissonResult == NSOrderedDescending) {
+  if (comparisonResult == NSOrderedDescending) {
     self.updateAvailable = YES;
-  } else if (comparissonResult == NSOrderedSame) {
+  } else if (comparisonResult == NSOrderedSame) {
     // compare using the binary UUID and stored version id
     self.updateAvailable = NO;
     if (_firstStartAfterInstall) {
@@ -881,8 +881,8 @@ typedef NS_ENUM(NSInteger, BITUpdateAlertViewTag) {
           // check if minOSVersion is set and this device qualifies
           BOOL deviceOSVersionQualifies = YES;
           if ([appVersionMetaInfo minOSVersion] && ![[appVersionMetaInfo minOSVersion] isKindOfClass:[NSNull class]]) {
-            NSComparisonResult comparissonResult = bit_versionCompare(appVersionMetaInfo.minOSVersion, [[UIDevice currentDevice] systemVersion]);
-            if (comparissonResult == NSOrderedDescending) {
+            NSComparisonResult comparisonResult = bit_versionCompare(appVersionMetaInfo.minOSVersion, [[UIDevice currentDevice] systemVersion]);
+            if (comparisonResult == NSOrderedDescending) {
               deviceOSVersionQualifies = NO;
             }
           }

--- a/Classes/BITUpdateViewController.m
+++ b/Classes/BITUpdateViewController.m
@@ -372,7 +372,7 @@
   [self restoreStoreButtonStateAnimated:NO];
   [self updateAppStoreHeader];
   
-  // clean up and remove any pending overservers
+  // clean up and remove any pending observers
   for (UITableViewCell *cell in _cells) {
     [cell removeObserver:self forKeyPath:@"webViewSize"];
   }

--- a/Classes/BITWebTableViewCell.m
+++ b/Classes/BITWebTableViewCell.m
@@ -111,7 +111,7 @@ body { font: 13px 'Helvetica Neue', Helvetica; color:#626262; word-wrap:break-wo
   if (_webViewContent != aWebViewContent) {
     _webViewContent = aWebViewContent;
     
-    // add basic accessiblity (prevents "snarfed from ivar layout") logs
+    // add basic accessibility (prevents "snarfed from ivar layout") logs
     self.accessibilityLabel = aWebViewContent;
   }
 }


### PR DESCRIPTION
Various spelling problems and typos.

I left alone words that were correct in one variation of English or another, like "customisation" or "-our" words.

There were a few that were part of internationalization or API. I didn't touch those.