### PR TITLE
Introduce deprecation for renamed public interfaces

### DIFF
--- a/Classes/BITCrashManager.h
+++ b/Classes/BITCrashManager.h
@@ -140,7 +140,7 @@ typedef NS_ENUM(NSUInteger, BITCrashManagerUserInput) {
  very slow.
  
  It is possible to check upon startup if the app crashed before using `didCrashInLastSession` and also how much
- time passed between the app launch and the crash using `timeintervalCrashInLastSessionOccurred`. This allows you
+ time passed between the app launch and the crash using `timeIntervalCrashInLastSessionOccurred`. This allows you
  to add additional code to your app delaying the app start until the crash has been successfully send if the crash
  occurred within a critical startup timeframe, e.g. after 10 seconds. The `BITCrashManagerDelegate` protocol provides
  various delegates to inform the app about it's current status so you can continue the remaining app startup setup
@@ -400,7 +400,7 @@ typedef NS_ENUM(NSUInteger, BITCrashManagerUserInput) {
  @see didCrashInLastSession
  @see BITCrashManagerDelegate
  */
-@property (nonatomic, readonly) NSTimeInterval timeintervalCrashInLastSessionOccurred;
+@property (nonatomic, readonly) NSTimeInterval timeIntervalCrashInLastSessionOccurred;
 
 
 ///-----------------------------------------------------------------------------
@@ -432,5 +432,11 @@ typedef NS_ENUM(NSUInteger, BITCrashManagerUserInput) {
  * If the SDK detects an App Store environment, it will _NOT_ cause the app to crash!
  */
 - (void)generateTestCrash;
+
+///-----------------------------------------------------------------------------
+/// @name Deprecated
+///-----------------------------------------------------------------------------
+
+@property (nonatomic, readonly) NSTimeInterval timeintervalCrashInLastSessionOccured DEPRECATED_MSG_ATTRIBUTE("Use the properly spelled property `timeIntervalCrashInLastSessionOccurred` instead.");
 
 @end

--- a/Classes/BITCrashManager.m
+++ b/Classes/BITCrashManager.m
@@ -137,7 +137,7 @@ static PLCrashReporterCallbacks plCrashCallbacks = {
     _crashIdenticalCurrentVersion = YES;
     
     _didCrashInLastSession = NO;
-    _timeintervalCrashInLastSessionOccurred = -1;
+    _timeIntervalCrashInLastSessionOccurred = -1;
     _didLogLowMemoryWarning = NO;
     
     _approvedCrashReports = [[NSMutableDictionary alloc] init];
@@ -797,7 +797,7 @@ static PLCrashReporterCallbacks plCrashCallbacks = {
           if (report.systemInfo.timestamp && report.processInfo.processStartTime) {
             appStartTime = report.processInfo.processStartTime;
             appCrashTime =report.systemInfo.timestamp;
-            _timeintervalCrashInLastSessionOccurred = [report.systemInfo.timestamp timeIntervalSinceDate:report.processInfo.processStartTime];
+            _timeIntervalCrashInLastSessionOccurred = [report.systemInfo.timestamp timeIntervalSinceDate:report.processInfo.processStartTime];
           }
         }
         
@@ -1519,6 +1519,10 @@ static PLCrashReporterCallbacks plCrashCallbacks = {
   BITHockeyLog(@"INFO: Sending crash reports started.");
 
   [self.hockeyAppClient enqeueHTTPOperation:operation];
+}
+
+- (NSTimeInterval)timeintervalCrashInLastSessionOccured {
+  return self.timeIntervalCrashInLastSessionOccurred;
 }
 
 @end

--- a/Classes/BITFeedbackListViewCell.h
+++ b/Classes/BITFeedbackListViewCell.h
@@ -85,4 +85,13 @@ typedef NS_ENUM(NSUInteger, BITFeedbackListViewCellBackgroundStyle) {
 
 - (void)setAttachments:(NSArray *)attachments;
 
+///-----------------------------------------------------------------------------
+/// @name Deprecated
+///-----------------------------------------------------------------------------
+
+typedef DEPRECATED_MSG_ATTRIBUTE("Use the properly spelled enum `BITFeedbackListViewCellPresentationStyle` instead.") NS_ENUM(NSUInteger, BITFeedbackListViewCellPresentatationStyle) {
+  BITFeedbackListViewCellPresentatationStyleDefault DEPRECATED_MSG_ATTRIBUTE("Use the properly spelled constant `BITFeedbackListViewCellPresentationStyleDefault` instead.") = 0,
+  BITFeedbackListViewCellPresentatationStyleOS7 DEPRECATED_MSG_ATTRIBUTE("Use the properly spelled constant `BITFeedbackListViewCellPresentationStyleOS7` instead.") = 1
+};
+
 @end


### PR DESCRIPTION
Unless you bump version to 4.0.0 for the next release, the changes introduced in 7eef1c4 as a followup to #139 would break [semantic versioning](http://semver.org) which states:
> Major version X (X.y.z | X > 0) MUST be incremented if any backwards incompatible changes are introduced to the public API

It doesn’t cost much to add these two deprecations and it will save some frustration to users updating to the next version of the Hockey SDK.