### PR TITLE
Add process ID to BITCrashDetails.

### DIFF
--- a/Classes/BITCrashDetails.h
+++ b/Classes/BITCrashDetails.h
@@ -86,6 +86,11 @@
 @property (nonatomic, readonly, strong) NSString *appBuild;
 
 /**
+ *  Identifier of the app process that crashed
+ */
+@property (nonatomic, readonly, assign) NSUInteger appProcessIdentifier;
+
+/**
  Indicates if the app was killed while being in foreground from the iOS
  
  If `[BITCrashManager enableAppNotTerminatingCleanlyDetection]` is enabled, use this on startup

--- a/Classes/BITCrashDetails.m
+++ b/Classes/BITCrashDetails.m
@@ -43,6 +43,7 @@ NSString *const kBITCrashKillSignal = @"SIGKILL";
                                  osVersion:(NSString *)osVersion
                                    osBuild:(NSString *)osBuild
                                   appBuild:(NSString *)appBuild
+                      appProcessIdentifier:(NSUInteger)appProcessIdentifier
 {
   if ((self = [super init])) {
     _incidentIdentifier = incidentIdentifier;
@@ -55,6 +56,7 @@ NSString *const kBITCrashKillSignal = @"SIGKILL";
     _osVersion = osVersion;
     _osBuild = osBuild;
     _appBuild = appBuild;
+    _appProcessIdentifier = appProcessIdentifier;
   }
   return self;
 }

--- a/Classes/BITCrashDetailsPrivate.h
+++ b/Classes/BITCrashDetailsPrivate.h
@@ -43,6 +43,7 @@ extern NSString *const __attribute__((unused)) kBITCrashKillSignal;
                                  crashTime:(NSDate *)crashTime
                                  osVersion:(NSString *)osVersion
                                    osBuild:(NSString *)osBuild
-                                  appBuild:(NSString *)appBuild;
+                                  appBuild:(NSString *)appBuild
+                      appProcessIdentifier:(NSUInteger)appProcessIdentifier;
 
 @end

--- a/Classes/BITCrashManager.m
+++ b/Classes/BITCrashManager.m
@@ -820,6 +820,7 @@ static PLCrashReporterCallbacks plCrashCallbacks = {
                                                                              osVersion:report.systemInfo.operatingSystemVersion
                                                                                osBuild:report.systemInfo.operatingSystemBuild
                                                                               appBuild:report.applicationInfo.applicationVersion
+                                                                  appProcessIdentifier:report.processInfo.processID
                                     ];
 
         // fetch and store the meta data after setting _lastSessionCrashDetails, so the property can be used in the protocol methods
@@ -1199,6 +1200,7 @@ static PLCrashReporterCallbacks plCrashCallbacks = {
                                                                        osVersion:fakeReportOSVersion
                                                                          osBuild:fakeReportOSBuild
                                                                         appBuild:fakeReportAppVersion
+                                                            appProcessIdentifier:[[NSProcessInfo processInfo] processIdentifier]
                               ];
 
   NSData *plist = [NSPropertyListSerialization dataWithPropertyList:(id)rootObj


### PR DESCRIPTION
I’m using the process ID of the crashed process [to query ASL](https://github.com/alloy/ARAnalytics/blob/add-breadcrumb-logging-to-HockeyApp/ARAnalyticalProvider.m#L138-L162)  for logs which I then [pass to HockeyApp](https://github.com/alloy/ARAnalytics/blob/add-breadcrumb-logging-to-HockeyApp/Providers/HockeyAppProvider.m#L83-L87) as breadcrumbs for what the app was doing.

I didn’t see any tests around the exposed crash details, so I didn’t add any either. Let me know if I need to do anything else.