### PR TITLE
Optional feedback add image button in feedback compose view

### DIFF
--- a/Classes/BITFeedbackComposeViewController.h
+++ b/Classes/BITFeedbackComposeViewController.h
@@ -70,6 +70,14 @@
 
 
 /**
+ Don't show the option to add images from the photo library
+ 
+ This is helpful if your application is landscape only, since the system UI for
+ selecting an image from the photo library is portrait only
+ */
+@property (nonatomic) BOOL hideImageAttachmentButton;
+
+/**
  An array of data objects that should be used to prefill the compose view content
  
  The following data object classes are currently supported:

--- a/Classes/BITFeedbackComposeViewController.m
+++ b/Classes/BITFeedbackComposeViewController.m
@@ -248,7 +248,9 @@
   
   [self.textAccessoryView addSubview:self.addPhotoButton];
   
-  self.textView.inputAccessoryView = self.textAccessoryView;
+  if (!self.hideImageAttachmentButton) {
+    self.textView.inputAccessoryView = self.textAccessoryView;
+  }
   
   // This could be a subclass, yet 
   self.attachmentScrollView = [[UIScrollView alloc] initWithFrame:CGRectZero];

--- a/Classes/BITFeedbackComposeViewController.m
+++ b/Classes/BITFeedbackComposeViewController.m
@@ -305,6 +305,7 @@
   } else {
     // Invoke delayed to fix iOS 7 iPad landscape bug, where this view will be moved if not called delayed
     [self.textView performSelector:@selector(becomeFirstResponder) withObject:nil afterDelay:0.0];
+    [self refreshAttachmentScrollview];
   }
 }
 

--- a/Classes/BITFeedbackManager.h
+++ b/Classes/BITFeedbackManager.h
@@ -234,6 +234,19 @@ typedef NS_ENUM(NSInteger, BITFeedbackObservationMode) {
 @property (nonatomic, copy) NSArray *feedbackComposerPreparedItems;
 
 
+/**
+ Don't show the option to add images from the photo library
+ 
+ This is helpful if your application is landscape only, since the system UI for
+ selecting an image from the photo library is portrait only
+ 
+ This setting is used for all feedback compose views that are created by the
+ `BITFeedbackManager`. If you invoke your own `BITFeedbackComposeViewController`,
+ then set the appropriate property on the view controller directl!.
+ */
+@property (nonatomic) BOOL feedbackComposeHideImageAttachmentButton;
+
+
 ///-----------------------------------------------------------------------------
 /// @name User Interface
 ///-----------------------------------------------------------------------------

--- a/Classes/BITFeedbackManager.m
+++ b/Classes/BITFeedbackManager.m
@@ -225,6 +225,7 @@ NSString *const kBITFeedbackUpdateAttachmentThumbnail = @"BITFeedbackUpdateAttac
 - (BITFeedbackComposeViewController *)feedbackComposeViewController {
   BITFeedbackComposeViewController *composeViewController = [[BITFeedbackComposeViewController alloc] init];
   [composeViewController prepareWithItems:self.feedbackComposerPreparedItems];
+  [composeViewController setHideImageAttachmentButton:self.feedbackComposeHideImageAttachmentButton];
     
   // by default set the delegate to be identical to the one of BITFeedbackManager
   [composeViewController setDelegate:self.delegate];


### PR DESCRIPTION
This adds an option to hide the `Add Image` button in the feedback compose view.

This is helpful if your application is landscape only, since the system UI for selecting an image from the photo library is portrait only.