### PR TITLE
Fix a few things

### DIFF
--- a/Classes/BITAuthenticator.m
+++ b/Classes/BITAuthenticator.m
@@ -27,13 +27,17 @@
  */
 
 
-#import "BITAuthenticator.h"
 #import "HockeySDK.h"
+
+#if HOCKEYSDK_FEATURE_AUTHENTICATOR
+
 #import "HockeySDKPrivate.h"
 #import "BITAuthenticator_Private.h"
+#import "BITAuthenticationViewController.h"
 #import "BITHTTPOperation.h"
 #import "BITHockeyAppClient.h"
 #import "BITHockeyHelper.h"
+#import "BITHockeyBaseManagerPrivate.h"
 
 #include <sys/stat.h>
 
@@ -908,3 +912,5 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
   }
 }
 @end
+
+#endif

--- a/Classes/BITAuthenticator_Private.h
+++ b/Classes/BITAuthenticator_Private.h
@@ -27,9 +27,12 @@
  */
 
 
-#import "BITAuthenticator.h"
-#import "BITHockeyBaseManagerPrivate.h"
+#import "HockeySDK.h"
+
+#if HOCKEYSDK_FEATURE_AUTHENTICATOR
+
 #import "BITAuthenticationViewController.h"
+
 @class BITHockeyAppClient;
 
 @interface BITAuthenticator ()<BITAuthenticationViewControllerDelegate, UIAlertViewDelegate>
@@ -93,3 +96,5 @@
 - (BOOL) needsValidation;
 - (void) authenticate;
 @end
+
+#endif

--- a/Classes/BITCrashDetailsPrivate.h
+++ b/Classes/BITCrashDetailsPrivate.h
@@ -26,8 +26,6 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#import <HockeySDK/HockeySDK.h>
-
 extern NSString *const __attribute__((unused)) kBITCrashKillSignal;
 
 @interface BITCrashDetails () {

--- a/Support/HockeySDK.xcodeproj/project.pbxproj
+++ b/Support/HockeySDK.xcodeproj/project.pbxproj
@@ -7,16 +7,16 @@
 	objects = {
 
 /* Begin PBXAggregateTarget section */
-		1E4F61E91621AD970033EFC5 /* HockeySDK Framework */ = {
+		1E4F61E91621AD970033EFC5 /* HockeySDK Distribution */ = {
 			isa = PBXAggregateTarget;
-			buildConfigurationList = 1E4F61EA1621AD970033EFC5 /* Build configuration list for PBXAggregateTarget "HockeySDK Framework" */;
+			buildConfigurationList = 1E4F61EA1621AD970033EFC5 /* Build configuration list for PBXAggregateTarget "HockeySDK Distribution" */;
 			buildPhases = (
 				1E4F61ED1621ADE70033EFC5 /* Build universal embedded framework */,
 			);
 			dependencies = (
 				1E754E431621F6290070AB92 /* PBXTargetDependency */,
 			);
-			name = "HockeySDK Framework";
+			name = "HockeySDK Distribution";
 			productName = "HockeySDK Framework";
 		};
 		1E8E66AD15BC3D7700632A2E /* HockeySDK Documentation */ = {
@@ -930,7 +930,7 @@
 				1E5954CB15B6F24A00A03429 /* HockeySDK */,
 				1E59550915B6F45800A03429 /* HockeySDKResources */,
 				1E8E66AD15BC3D7700632A2E /* HockeySDK Documentation */,
-				1E4F61E91621AD970033EFC5 /* HockeySDK Framework */,
+				1E4F61E91621AD970033EFC5 /* HockeySDK Distribution */,
 				1E5A458F16F0DFC200B55C04 /* HockeySDKTests */,
 			);
 		};
@@ -1653,7 +1653,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		1E4F61EA1621AD970033EFC5 /* Build configuration list for PBXAggregateTarget "HockeySDK Framework" */ = {
+		1E4F61EA1621AD970033EFC5 /* Build configuration list for PBXAggregateTarget "HockeySDK Distribution" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				1E4F61EB1621AD970033EFC5 /* Debug */,

--- a/Support/HockeySDK.xcodeproj/xcshareddata/xcschemes/HockeySDK Distribution.xcscheme
+++ b/Support/HockeySDK.xcodeproj/xcshareddata/xcschemes/HockeySDK Distribution.xcscheme
@@ -15,8 +15,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "1E4F61E91621AD970033EFC5"
-               BuildableName = "HockeySDK Framework"
-               BlueprintName = "HockeySDK Framework"
+               BuildableName = "HockeySDK Distribution"
+               BlueprintName = "HockeySDK Distribution"
                ReferencedContainer = "container:HockeySDK.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -43,8 +43,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "1E4F61E91621AD970033EFC5"
-            BuildableName = "HockeySDK Framework"
-            BlueprintName = "HockeySDK Framework"
+            BuildableName = "HockeySDK Distribution"
+            BlueprintName = "HockeySDK Distribution"
             ReferencedContainer = "container:HockeySDK.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/Support/HockeySDKTests/BITAuthenticatorTests.m
+++ b/Support/HockeySDKTests/BITAuthenticatorTests.m
@@ -15,8 +15,10 @@
 #import <OCMockitoIOS/OCMockitoIOS.h>
 
 #import "HockeySDK.h"
+#import "HockeySDKPrivate.h"
 #import "BITAuthenticator.h"
 #import "BITAuthenticator_Private.h"
+#import "BITHockeyBaseManagerPrivate.h"
 #import "BITHTTPOperation.h"
 #import "BITTestHelper.h"
 #import "BITHockeyAppClient.h"

--- a/Support/HockeySDKTests/BITCrashManagerTests.m
+++ b/Support/HockeySDKTests/BITCrashManagerTests.m
@@ -101,7 +101,6 @@
   } else {
     data = [[NSData alloc] initWithBase64Encoding:@"TestData"];
   }
-  }
 #endif
 
   NSString* type = @"text/plain";

--- a/Support/HockeySDKTests/BITCrashManagerTests.m
+++ b/Support/HockeySDKTests/BITCrashManagerTests.m
@@ -95,7 +95,7 @@
   
 #if __IPHONE_OS_VERSION_MIN_REQUIRED > __IPHONE_7_1
   data = [[NSData alloc] initWithBase64EncodedString:@"TestData" options:0];
-#elif
+#else
   if ([[NSData class] respondsToSelector:@selector(initWithBase64EncodedString:options:)]) {
     data = [[NSData alloc] initWithBase64EncodedString:@"TestData" options:0];
   } else {

--- a/Support/HockeySDKTests/BITCrashManagerTests.m
+++ b/Support/HockeySDKTests/BITCrashManagerTests.m
@@ -91,7 +91,19 @@
 
 - (void)testPersistAttachment {
   NSString *filename = @"TestAttachment";
-  NSData *data = [[NSData alloc] initWithBase64Encoding:@"TestData"];
+  NSData *data = nil;
+  
+#if __IPHONE_OS_VERSION_MIN_REQUIRED > __IPHONE_7_1
+  data = [[NSData alloc] initWithBase64EncodedString:@"TestData" options:0];
+#elif
+  if ([[NSData class] respondsToSelector:@selector(initWithBase64EncodedString:options:)]) {
+    data = [[NSData alloc] initWithBase64EncodedString:@"TestData" options:0];
+  } else {
+    data = [[NSData alloc] initWithBase64Encoding:@"TestData"];
+  }
+  }
+#endif
+
   NSString* type = @"text/plain";
   
   BITHockeyAttachment *originalAttachment = [[BITHockeyAttachment alloc] initWithFilename:filename hockeyAttachmentData:data contentType:type];

--- a/Support/HockeySDKTests/BITTestHelper.h
+++ b/Support/HockeySDKTests/BITTestHelper.h
@@ -1,3 +1,4 @@
+#import <Foundation/Foundation.h>
 
 @interface BITTestHelper : NSObject
 


### PR DESCRIPTION
- Fix compiler warning in test file when building with iOS 8 as deployment target
- Fix a few header includes that can cause compiler warnings when building test cases as part of a framework target
- Add `#if HOCKEYSDK_FEATURE_AUTHENTICATOR` statements to `BITAuthenticator` files (caused no issues, but should be there anyway)