### PR TITLE
Add delegate to BITFeedbackManagerDelegate

### DIFF
--- a/Classes/BITFeedbackManager.m
+++ b/Classes/BITFeedbackManager.m
@@ -114,7 +114,6 @@ NSString *const kBITFeedbackUpdateAttachmentThumbnail = @"BITFeedbackUpdateAttac
   [self unregisterObservers];
 }
 
-
 - (void)didBecomeActiveActions {
   if ([self isFeedbackManagerDisabled]) return;
   if (!_didEnterBackgroundState) return;
@@ -126,7 +125,10 @@ NSString *const kBITFeedbackUpdateAttachmentThumbnail = @"BITFeedbackUpdateAttac
   } else {
     [self updateAppDefinedUserData];
   }
-  [self updateMessagesList];
+  
+  if ([self allowFetchingNewMessages]) {
+    [self updateMessagesList];
+  }
 }
 
 - (void)didEnterBackgroundActions {
@@ -273,6 +275,16 @@ NSString *const kBITFeedbackUpdateAttachmentThumbnail = @"BITFeedbackUpdateAttac
       // do nothing, wait for active state
       break;
   }
+}
+
+- (BOOL)allowFetchingNewMessages {
+  BOOL fetchNewMessages = YES;
+  if ([BITHockeyManager sharedHockeyManager].delegate &&
+      [[BITHockeyManager sharedHockeyManager].delegate respondsToSelector:@selector(allowAutomaticFetchingForNewFeedbackForManager:)]) {
+    fetchNewMessages = [[BITHockeyManager sharedHockeyManager].delegate
+                        allowAutomaticFetchingForNewFeedbackForManager:self];
+  }
+  return fetchNewMessages;
 }
 
 - (void)updateMessagesList {

--- a/Classes/BITFeedbackManagerDelegate.h
+++ b/Classes/BITFeedbackManagerDelegate.h
@@ -47,4 +47,17 @@
  */
 - (void) feedbackManagerDidReceiveNewFeedback:(BITFeedbackManager*) feedbackManager;
 
+
+/**
+ *  Can be implemented to control wether the feedback manager should automatically
+ *  fetch for new messages on app startup or when becoming active.
+ *
+ *  By default the SDK fetches on app startup or when the app is becoming active again
+ *  if there are already messages existing or pending on the device.
+ *
+ *  You could disable it e.g. depending on available mobile network/WLAN connection
+ *  or let it fetch less frequently.
+ */
+- (BOOL) allowAutomaticFetchingForNewFeedbackForManager:(BITFeedbackManager *)feedbackManager;
+
 @end

--- a/Classes/BITFeedbackManagerPrivate.h
+++ b/Classes/BITFeedbackManagerPrivate.h
@@ -80,6 +80,9 @@ extern NSString *const kBITFeedbackUpdateAttachmentThumbnail;
 - (BOOL)updateUserNameUsingKeychainAndDelegate;
 - (BOOL)updateUserEmailUsingKeychainAndDelegate;
 
+// check if the user wants to influence when fetching of new messages may be done
+- (BOOL)allowFetchingNewMessages;
+
 // load new messages from the server
 - (void)updateMessagesList;
 

--- a/Support/HockeySDKTests/BITFeedbackManagerTests.m
+++ b/Support/HockeySDKTests/BITFeedbackManagerTests.m
@@ -207,5 +207,26 @@
   assertThat(_sut.userEmail, equalTo(@"test"));
 }
 
+- (void)testAllowFetchingNewMessages {
+    BOOL fetchMessages = NO;
+
+    // check the default
+    fetchMessages = [_sut allowFetchingNewMessages];
+    
+    assertThatBool(fetchMessages, equalToBool(YES));
+    
+    // check the delegate is implemented and returns NO
+    BITHockeyManager *hm = [BITHockeyManager sharedHockeyManager];
+    NSObject <BITHockeyManagerDelegate> *classMock = mockObjectAndProtocol([NSObject class], @protocol(BITHockeyManagerDelegate));
+    [given([classMock allowAutomaticFetchingForNewFeedbackForManager:_sut]) willReturn:NO];
+    hm.delegate = classMock;
+    _sut.delegate = classMock;
+    
+    fetchMessages = [_sut allowFetchingNewMessages];
+    
+    assertThatBool(fetchMessages, equalToBool(NO));
+    
+    [verifyCount(classMock, times(1)) allowAutomaticFetchingForNewFeedbackForManager:_sut];
+}
 
 @end


### PR DESCRIPTION
Added `allowAutomaticFetchingForNewFeedbackForManager:` which allows the developer to influence if the SDK should fetch for new messages on app startup and when the app is coming into foreground.

By default the SDK always checks in those cases if there are already messages existing.