### PR TITLE
Update framework search paths to be relative, so that framework target can build

### DIFF
--- a/Support/HockeySDK.xcodeproj/project.pbxproj
+++ b/Support/HockeySDK.xcodeproj/project.pbxproj
@@ -2005,7 +2005,7 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"/Users/andreaslinde/Sourcecode/HA/HockeySDK-iOSDemo/Vendor/HockeySDK/Vendor",
+					"$(PROJECT_DIR)/../Vendor",
 					"$(PROJECT_DIR)/HockeySDKTests",
 				);
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -2057,7 +2057,7 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"/Users/andreaslinde/Sourcecode/HA/HockeySDK-iOSDemo/Vendor/HockeySDK/Vendor",
+					"$(PROJECT_DIR)/../Vendor",
 					"$(PROJECT_DIR)/HockeySDKTests",
 				);
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -2106,7 +2106,7 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"/Users/andreaslinde/Sourcecode/HA/HockeySDK-iOSDemo/Vendor/HockeySDK/Vendor",
+					"$(PROJECT_DIR)/../Vendor",
 					"$(PROJECT_DIR)/HockeySDKTests",
 				);
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -2155,7 +2155,7 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"/Users/andreaslinde/Sourcecode/HA/HockeySDK-iOSDemo/Vendor/HockeySDK/Vendor",
+					"$(PROJECT_DIR)/../Vendor",
 					"$(PROJECT_DIR)/HockeySDKTests",
 				);
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -2198,7 +2198,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
-					"/Users/andreaslinde/Sourcecode/HA/HockeySDK-iOSDemo/Vendor/HockeySDK/Vendor",
+					"$(PROJECT_DIR)/../Vendor",
 					"$(PROJECT_DIR)/HockeySDKTests",
 				);
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -2239,7 +2239,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
-					"/Users/andreaslinde/Sourcecode/HA/HockeySDK-iOSDemo/Vendor/HockeySDK/Vendor",
+					"$(PROJECT_DIR)/../Vendor",
 					"$(PROJECT_DIR)/HockeySDKTests",
 				);
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -2277,7 +2277,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
-					"/Users/andreaslinde/Sourcecode/HA/HockeySDK-iOSDemo/Vendor/HockeySDK/Vendor",
+					"$(PROJECT_DIR)/../Vendor",
 					"$(PROJECT_DIR)/HockeySDKTests",
 				);
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -2315,7 +2315,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
-					"/Users/andreaslinde/Sourcecode/HA/HockeySDK-iOSDemo/Vendor/HockeySDK/Vendor",
+					"$(PROJECT_DIR)/../Vendor",
 					"$(PROJECT_DIR)/HockeySDKTests",
 				);
 				GCC_NO_COMMON_BLOCKS = YES;


### PR DESCRIPTION
This new pull request supersedes this older one: https://github.com/bitstadium/HockeySDK-iOS/pull/149

The new framework target works fine, except that one of the framework search paths was absolute, instead of relative to the project dir.  This pull request fixes that. :)