### PR TITLE
Existed module map in Support folder conflicts generated by CocoaPods one

### DIFF
--- a/HockeySDK.podspec
+++ b/HockeySDK.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.ios.vendored_frameworks = 'Vendor/CrashReporter.framework'
   s.xcconfig                = {'GCC_PREPROCESSOR_DEFINITIONS' => %{$(inherited) BITHOCKEY_VERSION="@\\"#{s.version}\\"" BITHOCKEY_C_VERSION="\\"#{s.version}\\"" BITHOCKEY_BUILD="@\\"38\\"" BITHOCKEY_C_BUILD="\\"38\\""} }
   s.resource_bundle         = { 'HockeySDKResources' => ['Resources/*.png', 'Resources/*.lproj'] }
-  s.preserve_paths          = 'Resources', 'Support'
+  s.preserve_paths          = 'Resources'
   s.private_header_files  = 'Classes/*Private.h'
 
 end


### PR DESCRIPTION
That leads to "Unable build HockeySDK module" error, because Xcode can't find the "HockeySDK.h" file, mentioned from module.modulemap. I have no idea, why Xcode even take in consideration your version of module.modulemap, since even not included to the project. Anyway, removing 'Support' directory from specs helped me.