### PR TITLE
Changed resources bundle identifier to prevent conflict with framework identifier

### DIFF
--- a/Resources/HockeySDK-Info.plist
+++ b/Resources/HockeySDK-Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIconFile</key>
 	<string></string>
 	<key>CFBundleIdentifier</key>
-	<string>net.hockeyapp.sdk.ios</string>
+	<string>net.hockeyapp.sdk.resources.ios</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
On submitting to the App Store, my binary was failing validation because of bundle name conflicts (I am using HockeyApp as a dynamic framework).
It would seem that this is due to the framework including a resources bundle which has the same identifier as the actual framework.
Obviously the name used is not important, but it is better to avoid conflicts.