### PR TITLE
Disable tracking the installation on a device

### DIFF
--- a/Classes/BITAuthenticator.m
+++ b/Classes/BITAuthenticator.m
@@ -339,7 +339,7 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
   NSParameterAssert(self.installationIdentifier);
   NSParameterAssert(self.installationIdentifierParameterString);
   
-  NSString *installString = bit_appAnonID();
+  NSString *installString = bit_appAnonID(NO);
   if (installString) {
     return @{self.installationIdentifierParameterString : self.installationIdentifier, @"install_string": installString};
   }
@@ -440,7 +440,7 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
   NSString *authenticationPath = [self authenticationPath];
   NSMutableDictionary *params = [NSMutableDictionary dictionary];
   
-  NSString *installString = bit_appAnonID();
+  NSString *installString = bit_appAnonID(NO);
   if (installString) {
     params[@"install_string"] = installString;
   }

--- a/Classes/BITCrashManager.m
+++ b/Classes/BITCrashManager.m
@@ -810,7 +810,7 @@ static PLCrashReporterCallbacks plCrashCallbacks = {
           incidentIdentifier = (NSString *) CFBridgingRelease(CFUUIDCreateString(NULL, report.uuidRef));
         }
         
-        NSString *reporterKey = bit_appAnonID() ?: @"";
+        NSString *reporterKey = bit_appAnonID(NO) ?: @"";
 
         _lastSessionCrashDetails = [[BITCrashDetails alloc] initWithIncidentIdentifier:incidentIdentifier
                                                                            reporterKey:reporterKey
@@ -1136,7 +1136,7 @@ static PLCrashReporterCallbacks plCrashCallbacks = {
  */
 - (void)createCrashReportForAppKill {
   NSString *fakeReportUUID = bit_UUID();
-  NSString *fakeReporterKey = bit_appAnonID() ?: @"???";
+  NSString *fakeReporterKey = bit_appAnonID(NO) ?: @"???";
   
   NSString *fakeReportAppVersion = [[NSUserDefaults standardUserDefaults] objectForKey:kBITAppVersion];
   if (!fakeReportAppVersion)
@@ -1294,7 +1294,7 @@ static PLCrashReporterCallbacks plCrashCallbacks = {
       return;
     }
     
-    installString = bit_appAnonID() ?: @"";
+    installString = bit_appAnonID(NO) ?: @"";
     
     if (report) {
       if (report.uuidRef != NULL) {

--- a/Classes/BITFeedbackManager.m
+++ b/Classes/BITFeedbackManager.m
@@ -883,7 +883,7 @@ NSString *const kBITFeedbackUpdateAttachmentThumbnail = @"BITFeedbackUpdateAttac
     [postBody appendData:[BITHockeyAppClient dataWithPostValue:[message text] forKey:@"text" boundary:boundary]];
     [postBody appendData:[BITHockeyAppClient dataWithPostValue:[message token] forKey:@"message_token" boundary:boundary]];
     
-    NSString *installString = bit_appAnonID();
+    NSString *installString = bit_appAnonID(NO);
     if (installString) {
       [postBody appendData:[BITHockeyAppClient dataWithPostValue:installString forKey:@"install_string" boundary:boundary]];
     }

--- a/Classes/BITHockeyHelper.h
+++ b/Classes/BITHockeyHelper.h
@@ -45,7 +45,7 @@ NSString *bit_encodeAppIdentifier(NSString *inputString);
 NSString *bit_appName(NSString *placeHolderString);
 NSString *bit_UUIDPreiOS6(void);
 NSString *bit_UUID(void);
-NSString *bit_appAnonID(void);
+NSString *bit_appAnonID(BOOL forceNewAnonID);
 BOOL bit_isPreiOS7Environment(void);
 BOOL bit_isPreiOS8Environment(void);
 BOOL bit_isRunningInAppExtension(void);

--- a/Classes/BITHockeyHelper.m
+++ b/Classes/BITHockeyHelper.m
@@ -191,34 +191,50 @@ NSString *bit_UUID(void) {
   return resultUUID;
 }
 
-NSString *bit_appAnonID(void) {
+NSString *bit_appAnonID(BOOL forceNewAnonID) {
   static NSString *appAnonID = nil;
   static dispatch_once_t predAppAnonID;
+  __block NSError *error = nil;
+  NSString *appAnonIDKey = @"appAnonID";
   
-  dispatch_once(&predAppAnonID, ^{
-    // first check if we already have an install string in the keychain
-    NSString *appAnonIDKey = @"appAnonID";
-    
-    __block NSError *error = nil;
-    appAnonID = [BITKeychainUtils getPasswordForUsername:appAnonIDKey andServiceName:bit_keychainHockeySDKServiceName() error:&error];
-    
-    if (!appAnonID) {
-      appAnonID = bit_UUID();
-      // store this UUID in the keychain (on this device only) so we can be sure to always have the same ID upon app startups
-      if (appAnonID) {
-        // add to keychain in a background thread, since we got reports that storing to the keychain may take several seconds sometimes and cause the app to be killed
-        // and we don't care about the result anyway
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_LOW, 0), ^{
-          [BITKeychainUtils storeUsername:appAnonIDKey
-                              andPassword:appAnonID
-                           forServiceName:bit_keychainHockeySDKServiceName()
-                           updateExisting:YES
-                            accessibility:kSecAttrAccessibleAlwaysThisDeviceOnly
-                                    error:&error];
-        });
-      }
+  if (forceNewAnonID) {
+    appAnonID = bit_UUID();
+    // store this UUID in the keychain (on this device only) so we can be sure to always have the same ID upon app startups
+    if (appAnonID) {
+      // add to keychain in a background thread, since we got reports that storing to the keychain may take several seconds sometimes and cause the app to be killed
+      // and we don't care about the result anyway
+      dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_LOW, 0), ^{
+        [BITKeychainUtils storeUsername:appAnonIDKey
+                            andPassword:appAnonID
+                         forServiceName:bit_keychainHockeySDKServiceName()
+                         updateExisting:YES
+                          accessibility:kSecAttrAccessibleAlwaysThisDeviceOnly
+                                  error:&error];
+      });
     }
-  });
+  } else {
+    dispatch_once(&predAppAnonID, ^{
+      // first check if we already have an install string in the keychain
+      appAnonID = [BITKeychainUtils getPasswordForUsername:appAnonIDKey andServiceName:bit_keychainHockeySDKServiceName() error:&error];
+      
+      if (!appAnonID) {
+        appAnonID = bit_UUID();
+        // store this UUID in the keychain (on this device only) so we can be sure to always have the same ID upon app startups
+        if (appAnonID) {
+          // add to keychain in a background thread, since we got reports that storing to the keychain may take several seconds sometimes and cause the app to be killed
+          // and we don't care about the result anyway
+          dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_LOW, 0), ^{
+            [BITKeychainUtils storeUsername:appAnonIDKey
+                                andPassword:appAnonID
+                             forServiceName:bit_keychainHockeySDKServiceName()
+                             updateExisting:YES
+                              accessibility:kSecAttrAccessibleAlwaysThisDeviceOnly
+                                      error:&error];
+          });
+        }
+      }
+    });
+  }
   
   return appAnonID;
 }

--- a/Classes/BITHockeyManager.h
+++ b/Classes/BITHockeyManager.h
@@ -398,6 +398,21 @@
 @property (nonatomic, readonly) NSString *installString;
 
 
+/**
+ Disable tracking the installation of an app on a device
+ 
+ This will cause the app to generate a new `installString` value every time the
+ app is cold started.
+ 
+ This property is only considered in App Store Environment, since it would otherwise
+ affect the `BITUpdateManager` and `BITAuthenticator` functionalities!
+ 
+ @warning This property needs to be set before calling `startManager`
+ 
+ *Default*: _NO_
+ */
+@property (nonatomic, getter=isInstallTrackingDisabled) BOOL disableInstallTracking;
+
 ///-----------------------------------------------------------------------------
 /// @name Debug Logging
 ///-----------------------------------------------------------------------------

--- a/Classes/BITHockeyManager.m
+++ b/Classes/BITHockeyManager.m
@@ -161,7 +161,8 @@ bitstadium_info_t bitstadium_library_info __attribute__((section("__TEXT,__bit_h
     _startUpdateManagerIsInvoked = NO;
     
     _liveIdentifier = nil;
-    _installString = bit_appAnonID();
+    _installString = bit_appAnonID(NO);
+    _disableInstallTracking = NO;
     
 #if !TARGET_IPHONE_SIMULATOR
     // check if we are really in an app store environment
@@ -229,6 +230,10 @@ bitstadium_info_t bitstadium_library_info __attribute__((section("__TEXT,__bit_h
   
   if (![self isSetUpOnMainThread]) return;
   
+  if ([self isAppStoreEnvironment] && [self isInstallTrackingDisabled]) {
+    _installString = bit_appAnonID(YES);
+  }
+
   BITHockeyLog(@"INFO: Starting HockeyManager");
   _startManagerIsInvoked = YES;
   

--- a/Support/HockeySDKTests/BITHockeyHelperTests.m
+++ b/Support/HockeySDKTests/BITHockeyHelperTests.m
@@ -80,7 +80,7 @@
                            andServiceName:bit_keychainHockeySDKServiceName()
                                     error:&error];
   
-  NSString *resultString = bit_appAnonID();
+  NSString *resultString = bit_appAnonID(NO);
   assertThat(resultString, notNilValue());
   assertThatInteger([resultString length], equalToInteger(36));
 }


### PR DESCRIPTION
The new property will cause the app to generate a new `installString` value every time the app is cold started.

The property is only considered in App Store Environment, since it would otherwise affect the `BITUpdateManager` and `BITAuthenticator` functionalities!

Default is NO.