### PR TITLE
CocoaPod specs update

### DIFF
--- a/Classes/HockeySDKFeatureConfig_CP.h
+++ b/Classes/HockeySDKFeatureConfig_CP.h
@@ -1,0 +1,87 @@
+/*
+ * Author: Andreas Linde <mail@andreaslinde.de>
+ *
+ * Copyright (c) 2013-2014 HockeyApp, Bit Stadium GmbH.
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+ 
+/*
+ * This is intended to be used only by Cocoapods
+ */
+
+#ifndef HockeySDK_HockeySDKFeatureConfig_h
+#define HockeySDK_HockeySDKFeatureConfig_h
+
+
+/**
+ * If true, include support for handling crash reports
+ *
+ * _Default_: Disabled
+ */
+#ifndef HOCKEYSDK_FEATURE_CRASH_REPORTER
+#    define HOCKEYSDK_FEATURE_CRASH_REPORTER 0
+#endif /* HOCKEYSDK_FEATURE_CRASH_REPORTER */
+
+
+/**
+ * If true, include support for managing user feedback
+ *
+ * _Default_: Disabled
+ */
+#ifndef HOCKEYSDK_FEATURE_FEEDBACK
+#    define HOCKEYSDK_FEATURE_FEEDBACK 0
+#endif /* HOCKEYSDK_FEATURE_FEEDBACK */
+
+
+/**
+ * If true, include support for informing the user about new updates pending in the App Store
+ *
+ * _Default_: Disabled
+ */
+#ifndef HOCKEYSDK_FEATURE_STORE_UPDATES
+#    define HOCKEYSDK_FEATURE_STORE_UPDATES 0
+#endif /* HOCKEYSDK_FEATURE_STORE_UPDATES */
+
+
+/**
+ * If true, include support for authentication installations for Ad-Hoc and Enterprise builds
+ *
+ * _Default_: Disabled
+ */
+#ifndef HOCKEYSDK_FEATURE_AUTHENTICATOR
+#    define HOCKEYSDK_FEATURE_AUTHENTICATOR 0
+#endif /* HOCKEYSDK_FEATURE_AUTHENTICATOR */
+
+
+/**
+ * If true, include support for handling in-app updates for Ad-Hoc and Enterprise builds
+ *
+ * _Default_: Disabled
+ */
+#ifndef HOCKEYSDK_FEATURE_UPDATES
+#    define HOCKEYSDK_FEATURE_UPDATES 0
+#endif /* HOCKEYSDK_FEATURE_UPDATES */
+
+
+#endif /* HockeySDK_HockeySDKFeatureConfig_h */

--- a/HockeySDK-Source.podspec
+++ b/HockeySDK-Source.podspec
@@ -1,0 +1,80 @@
+Pod::Spec.new do |s|
+  s.name              = 'HockeySDK-Source'
+  s.version           = '3.6.4'
+
+  s.summary           = 'Collect live crash reports, get feedback from your users, distribute your betas, and analyze your test coverage with HockeyApp.'
+  s.description       = <<-DESC
+                        HockeyApp is a service to distribute beta apps, collect crash reports and
+                        communicate with your app's users.
+                        
+                        It improves the testing process dramatically and can be used for both beta
+                        and App Store builds.
+                        DESC
+
+  s.homepage          = 'http://hockeyapp.net/'
+  s.documentation_url = 'http://hockeyapp.net/help/sdk/ios/3.6.4/'
+
+  s.license           = { :type => 'MIT', :file => 'LICENSE' }
+  s.author            = { 'Andreas Linde' => 'mail@andreaslinde.de', 'Thomas Dohmke' => "thomas@dohmke.de" }
+  s.source            = { :git => 'https://github.com/bitstadium/HockeySDK-iOS.git', :tag => s.version.to_s }
+
+  s.platform          = :ios, '6.0'
+  s.requires_arc      = true
+    
+  s.prepare_command       = 'cp -f Classes/HockeySDKFeatureConfig_CP.h Classes/HockeySDKFeatureConfig.h' #Changes default of all features enabled to disabled
+  s.frameworks            = 'Security', 'UIKit'
+  s.resource_bundle       = { 'HockeySDKResources' => ['Resources/*.lproj'] }
+  s.preserve_path         = 'README.md'
+  s.private_header_files  = 'Classes/*Private.h'
+  s.xcconfig              = {'GCC_PREPROCESSOR_DEFINITIONS' => %{$(inherited) BITHOCKEY_VERSION="@\\"#{s.version}\\"" BITHOCKEY_C_VERSION="\\"#{s.version}\\"" BITHOCKEY_BUILD="@\\"38\\"" BITHOCKEY_C_BUILD="\\"38\\""} }
+  
+  s.default_subspec = 'AllFeatures'
+
+  s.subspec 'SharedRequirements' do |ss|
+    ss.source_files  = 'Classes/HockeySDK*.{h,m}', 'Classes/BITHockeyManager*.{h,m}', 'Classes/BITHockeyAppClient.{h,m}', 'Classes/BITHTTPOperation.{h,m}', 'Classes/BITHockeyHelper.{h,m}', 'Classes/BITKeychain*.{h,m}', 'Classes/BITHockeyBaseManager*.{h,m}'
+  end
+  
+  s.subspec 'CrashReporter' do |ss|
+    ss.dependency 'HockeySDK-Source/SharedRequirements'
+    ss.vendored_frameworks = 'Vendor/CrashReporter.framework'
+    ss.frameworks = 'SystemConfiguration'
+    ss.libraries = 'c++'
+    ss.source_files = 'Classes/BITCrash*.{h,m,mm}', 'Classes/BITHockeyAttachment.{h,m}'
+    ss.xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS' => %{$(inherited) HOCKEYSDK_FEATURE_CRASH_REPORTER=1} }
+  end
+  
+  s.subspec 'UserFeedback' do |ss|
+    ss.dependency 'HockeySDK-Source/SharedRequirements'
+    ss.frameworks = 'AssetsLibrary', 'MobileCoreServices', 'QuickLook', 'CoreText'
+    ss.source_files = 'Classes/BITFeedback*.{h,m}', 'Classes/BIT*ImageAnnotation.{h,m}', 'Classes/BITImageAnnotationViewController.{h,m}', 'Classes/BITHockeyAttachment.{h,m}', 'Classes/BITHockeyBaseViewController.{h,m}', 'Classes/BITAttributedLabel.{h,m}', 'Classes/BITActivityIndicatorButton.{h,m}'
+    ss.xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS' => %{$(inherited) HOCKEYSDK_FEATURE_FEEDBACK=1} }
+  end
+  
+  s.subspec 'StoreUpdates' do |ss|
+    ss.dependency 'HockeySDK-Source/SharedRequirements'
+    ss.source_files = 'Classes/BITStoreUpdate*.{h,m}'
+    ss.xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS' => %{$(inherited) HOCKEYSDK_FEATURE_STORE_UPDATES=1} }
+  end
+  
+  s.subspec 'Authenticator' do |ss|
+    ss.dependency 'HockeySDK-Source/SharedRequirements'
+    ss.source_files = 'Classes/BITAuthentica*.{h,m}', 'Classes/BITHockeyBaseViewController.{h,m}' 
+    ss.xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS' => %{$(inherited) HOCKEYSDK_FEATURE_AUTHENTICATOR=1} }
+  end
+  
+  s.subspec 'AdHocUpdates' do |ss|
+    ss.dependency 'HockeySDK-Source/SharedRequirements'
+    ss.source_files = 'Classes/BITUpdate*.{h,m}', 'Classes/BITAppVersionMetaInfo.{h,m}', 'Classes/BITHockeyBaseViewController.{h,m}', 'Classes/BITStoreButton.{h,m}', 'Classes/BITAppStoreHeader.{h,m}', 'Classes/BITWebTableViewCell.{h,m}'
+    ss.frameworks = 'CoreGraphics', 'QuartzCore', 'Security', 'UIKit'
+    ss.xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS' => %{$(inherited) HOCKEYSDK_FEATURE_UPDATES=1} }
+  end
+  
+  s.subspec 'AllFeatures' do |ss|
+    ss.dependency 'HockeySDK-Source/CrashReporter'
+    ss.dependency 'HockeySDK-Source/UserFeedback'
+    ss.dependency 'HockeySDK-Source/StoreUpdates'
+    ss.dependency 'HockeySDK-Source/Authenticator'
+    ss.dependency 'HockeySDK-Source/AdHocUpdates'
+  end
+
+end

--- a/HockeySDK.podspec
+++ b/HockeySDK.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   
   s.subspec 'SharedRequirements' do |ss|
     ss.source_files = 'Classes/HockeySDK*.{h,m}', 'Classes/BITHockeyManager*.{h,m}', 'Classes/BITHockeyAppClient.{h,m}', 'Classes/BITHTTPOperation.{h,m}', 'Classes/BITHockeyHelper.{h,m}', 'Classes/BITKeychain*.{h,m}', 'Classes/BITHockeyBaseManager*.{h,m}'
-    ss.frameworks = 'CoreText', 'CoreGraphics', 'QuartzCore', 'Security', 'UIKit'
+    ss.frameworks = 'CoreGraphics', 'QuartzCore', 'Security', 'UIKit'
     ss.resource_bundle         = { 'HockeySDKResources' => ['Resources/*.png', 'Resources/*.lproj'] }
     ss.preserve_paths          = 'Resources', 'Support'
     ss.private_header_files  = 'Classes/*Private.h'
@@ -42,7 +42,7 @@ Pod::Spec.new do |s|
   
   s.subspec 'UserFeedback' do |ss|
     ss.dependency 'HockeySDK/SharedRequirements'
-    ss.frameworks = 'AssetsLibrary', 'MobileCoreServices', 'QuickLook'
+    ss.frameworks = 'AssetsLibrary', 'MobileCoreServices', 'QuickLook', 'CoreText'
     ss.source_files = 'Classes/BITFeedback*.{h,m}', 'Classes/BIT*ImageAnnotation.{h,m}', 'Classes/BITImageAnnotationViewController.{h,m}', 'Classes/BITHockeyAttachment.{h,m}', 'Classes/BITHockeyBaseViewController.{h,m}', 'Classes/BITAttributedLabel.{h,m}', 'Classes/BITActivityIndicatorButton.{h,m}'
     ss.xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS' => %{$(inherited) HOCKEYSDK_FEATURE_FEEDBACK=1} }
   end

--- a/HockeySDK.podspec
+++ b/HockeySDK.podspec
@@ -24,6 +24,7 @@ Pod::Spec.new do |s|
   s.default_subspec = 'CompiledLib'
   
   s.subspec 'SharedRequirements' do |ss|
+    ss.prepare_command = 'mv -f Classes/HockeySDKFeatureConfig_CP.h Classes/HockeySDKFeatureConfig.h' #Changes default of everything enabled to disabled
     ss.source_files = 'Classes/HockeySDK*.{h,m}', 'Classes/BITHockeyManager*.{h,m}', 'Classes/BITHockeyAppClient.{h,m}', 'Classes/BITHTTPOperation.{h,m}', 'Classes/BITHockeyHelper.{h,m}', 'Classes/BITKeychain*.{h,m}', 'Classes/BITHockeyBaseManager*.{h,m}'
     ss.frameworks = 'CoreGraphics', 'QuartzCore', 'Security', 'UIKit'
     ss.resource_bundle         = { 'HockeySDKResources' => ['Resources/*.png', 'Resources/*.lproj'] }

--- a/HockeySDK.podspec
+++ b/HockeySDK.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   s.platform          = :ios, '6.0'
   s.requires_arc      = true
   
-  s.default_subspec = 'All'
+  s.default_subspec = 'CompiledLib'
   
   s.subspec 'SharedRequirements' do |ss|
     ss.source_files = 'Classes/HockeySDK*.{h,m}', 'Classes/BITHockeyManager*.{h,m}', 'Classes/BITHockeyAppClient.{h,m}', 'Classes/BITHTTPOperation.{h,m}', 'Classes/BITHockeyHelper.{h,m}', 'Classes/BITKeychain*.{h,m}', 'Classes/BITHockeyBaseManager*.{h,m}'
@@ -65,7 +65,7 @@ Pod::Spec.new do |s|
     ss.xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS' => %{$(inherited) HOCKEYSDK_FEATURE_UPDATES=1} }
   end
   
-  s.subspec 'All' do |ss|
+  s.subspec 'CompiledLib' do |ss|
     ss.dependency 'HockeySDK/CrashReporter'
     ss.dependency 'HockeySDK/UserFeedback'
     ss.dependency 'HockeySDK/StoreUpdates'

--- a/HockeySDK.podspec
+++ b/HockeySDK.podspec
@@ -26,8 +26,9 @@ Pod::Spec.new do |s|
   s.subspec 'SharedRequirements' do |ss|
     ss.prepare_command = 'mv -f Classes/HockeySDKFeatureConfig_CP.h Classes/HockeySDKFeatureConfig.h' #Changes default of everything enabled to disabled
     ss.source_files = 'Classes/HockeySDK*.{h,m}', 'Classes/BITHockeyManager*.{h,m}', 'Classes/BITHockeyAppClient.{h,m}', 'Classes/BITHTTPOperation.{h,m}', 'Classes/BITHockeyHelper.{h,m}', 'Classes/BITKeychain*.{h,m}', 'Classes/BITHockeyBaseManager*.{h,m}'
+    #Include .png resources in the subspecs that need them
     ss.frameworks = 'CoreGraphics', 'QuartzCore', 'Security', 'UIKit'
-    ss.resource_bundle         = { 'HockeySDKResources' => ['Resources/*.png', 'Resources/*.lproj'] }
+    ss.resource_bundle         = { 'HockeySDKResources' => ['Resources/*.lproj'] }
     ss.preserve_paths          = 'Resources', 'Support'
     ss.private_header_files  = 'Classes/*Private.h'
     ss.xcconfig                = {'GCC_PREPROCESSOR_DEFINITIONS' => %{$(inherited) BITHOCKEY_VERSION="@\\"#{s.version}\\"" BITHOCKEY_C_VERSION="\\"#{s.version}\\"" BITHOCKEY_BUILD="@\\"38\\"" BITHOCKEY_C_BUILD="\\"38\\""} }

--- a/HockeySDK.podspec
+++ b/HockeySDK.podspec
@@ -19,15 +19,58 @@ Pod::Spec.new do |s|
   s.source            = { :git => 'https://github.com/bitstadium/HockeySDK-iOS.git', :tag => s.version.to_s }
 
   s.platform          = :ios, '6.0'
-  s.source_files      = 'Classes'
   s.requires_arc      = true
   
-  s.frameworks              = 'AssetsLibrary', 'CoreText', 'CoreGraphics', 'MobileCoreServices', 'QuartzCore', 'QuickLook', 'Security', 'SystemConfiguration', 'UIKit'
-  s.libraries               = 'c++'
-  s.ios.vendored_frameworks = 'Vendor/CrashReporter.framework'
-  s.xcconfig                = {'GCC_PREPROCESSOR_DEFINITIONS' => %{$(inherited) BITHOCKEY_VERSION="@\\"#{s.version}\\"" BITHOCKEY_C_VERSION="\\"#{s.version}\\"" BITHOCKEY_BUILD="@\\"38\\"" BITHOCKEY_C_BUILD="\\"38\\""} }
-  s.resource_bundle         = { 'HockeySDKResources' => ['Resources/*.png', 'Resources/*.lproj'] }
-  s.preserve_paths          = 'Resources'
-  s.private_header_files  = 'Classes/*Private.h'
+  s.default_subspec = 'All'
+  
+  s.subspec 'SharedRequirements' do |ss|
+    ss.source_files = 'Classes/HockeySDK*.{h,m}', 'Classes/BITHockeyManager*.{h,m}', 'Classes/BITHockeyAppClient.{h,m}', 'Classes/BITHTTPOperation.{h,m}', 'Classes/BITHockeyHelper.{h,m}', 'Classes/BITKeychain*.{h,m}', 'Classes/BITHockeyBaseManager*.{h,m}'
+    ss.frameworks = 'CoreText', 'CoreGraphics', 'QuartzCore', 'Security', 'UIKit'
+    ss.resource_bundle         = { 'HockeySDKResources' => ['Resources/*.png', 'Resources/*.lproj'] }
+    ss.preserve_paths          = 'Resources', 'Support'
+    ss.private_header_files  = 'Classes/*Private.h'
+    ss.xcconfig                = {'GCC_PREPROCESSOR_DEFINITIONS' => %{$(inherited) BITHOCKEY_VERSION="@\\"#{s.version}\\"" BITHOCKEY_C_VERSION="\\"#{s.version}\\"" BITHOCKEY_BUILD="@\\"38\\"" BITHOCKEY_C_BUILD="\\"38\\""} }
+  end
+  
+  s.subspec 'CrashReporter' do |ss|
+    ss.dependency 'HockeySDK/SharedRequirements'
+    ss.ios.vendored_frameworks = 'Vendor/CrashReporter.framework'
+    ss.frameworks = 'SystemConfiguration'
+    ss.source_files = 'Classes/BITCrash*.{h,m}', 'Classes/BITHockeyAttachment.{h,m}'
+    ss.xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS' => %{$(inherited) HOCKEYSDK_FEATURE_CRASH_REPORTER=1} }
+  end
+  
+  s.subspec 'UserFeedback' do |ss|
+    ss.dependency 'HockeySDK/SharedRequirements'
+    ss.frameworks = 'AssetsLibrary', 'MobileCoreServices', 'QuickLook'
+    ss.source_files = 'Classes/BITFeedback*.{h,m}', 'Classes/BIT*ImageAnnotation.{h,m}', 'Classes/BITImageAnnotationViewController.{h,m}', 'Classes/BITHockeyAttachment.{h,m}', 'Classes/BITHockeyBaseViewController.{h,m}', 'Classes/BITAttributedLabel.{h,m}', 'Classes/BITActivityIndicatorButton.{h,m}'
+    ss.xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS' => %{$(inherited) HOCKEYSDK_FEATURE_FEEDBACK=1} }
+  end
+  
+  s.subspec 'StoreUpdates' do |ss|
+    ss.dependency 'HockeySDK/SharedRequirements'
+    ss.source_files = 'Classes/BITStoreUpdate*.{h,m}'
+    ss.xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS' => %{$(inherited) HOCKEYSDK_FEATURE_STORE_UPDATES=1} }
+  end
+  
+  s.subspec 'Authenticator' do |ss|
+    ss.dependency 'HockeySDK/SharedRequirements'
+    ss.source_files = 'Classes/BITAuthentica*.{h,m}', 'Classes/BITHockeyBaseViewController.{h,m}' 
+    ss.xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS' => %{$(inherited) HOCKEYSDK_FEATURE_AUTHENTICATOR=1} }
+  end
+  
+  s.subspec 'AdHocUpdates' do |ss|
+    ss.dependency 'HockeySDK/SharedRequirements'
+    ss.source_files = 'Classes/BITUpdate*.{h,m}', 'Classes/BITAppVersionMetaInfo.{h,m}', 'Classes/BITHockeyBaseViewController.{h,m}', 'Classes/BITStoreButton.{h,m}', 'Classes/BITAppStoreHeader.{h,m}', 'Classes/BITWebTableViewCell.{h,m}'
+    ss.xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS' => %{$(inherited) HOCKEYSDK_FEATURE_UPDATES=1} }
+  end
+  
+  s.subspec 'All' do |ss|
+    ss.dependency 'HockeySDK/CrashReporter'
+    ss.dependency 'HockeySDK/UserFeedback'
+    ss.dependency 'HockeySDK/StoreUpdates'
+    ss.dependency 'HockeySDK/Authenticator'
+    ss.dependency 'HockeySDK/AdHocUpdates'
+  end
 
 end

--- a/HockeySDK.podspec
+++ b/HockeySDK.podspec
@@ -14,65 +14,31 @@ Pod::Spec.new do |s|
   s.homepage          = 'http://hockeyapp.net/'
   s.documentation_url = 'http://hockeyapp.net/help/sdk/ios/3.6.4/'
 
-  s.license           = 'MIT'
+  s.license           = { :type => 'MIT', :file => 'HockeySDK-iOS/LICENSE' }
   s.author            = { 'Andreas Linde' => 'mail@andreaslinde.de', 'Thomas Dohmke' => "thomas@dohmke.de" }
-  s.source            = { :git => 'https://github.com/bitstadium/HockeySDK-iOS.git', :tag => s.version.to_s }
 
   s.platform          = :ios, '6.0'
   s.requires_arc      = true
   
-  s.default_subspec = 'CompiledLib'
+  s.preserve_path = 'HockeySDK-iOS/README.md'
+
+  s.source = { :http => "https://github.com/bitstadium/HockeySDK-iOS/releases/download/#{s.version}/HockeySDK-iOS-#{s.version}.zip" }
+
+  s.frameworks = 'SystemConfiguration', 'Security', 'UIKit'
+  s.libraries = 'c++'
+
+  s.default_subspec   = 'AllFeaturesLib'
   
-  s.subspec 'SharedRequirements' do |ss|
-    ss.prepare_command = 'mv -f Classes/HockeySDKFeatureConfig_CP.h Classes/HockeySDKFeatureConfig.h' #Changes default of everything enabled to disabled
-    ss.source_files = 'Classes/HockeySDK*.{h,m}', 'Classes/BITHockeyManager*.{h,m}', 'Classes/BITHockeyAppClient.{h,m}', 'Classes/BITHTTPOperation.{h,m}', 'Classes/BITHockeyHelper.{h,m}', 'Classes/BITKeychain*.{h,m}', 'Classes/BITHockeyBaseManager*.{h,m}'
-    #Include .png resources in the subspecs that need them
-    ss.frameworks = 'CoreGraphics', 'QuartzCore', 'Security', 'UIKit'
-    ss.resource_bundle         = { 'HockeySDKResources' => ['Resources/*.lproj'] }
-    ss.preserve_paths          = 'Resources', 'Support'
-    ss.private_header_files  = 'Classes/*Private.h'
-    ss.xcconfig                = {'GCC_PREPROCESSOR_DEFINITIONS' => %{$(inherited) BITHOCKEY_VERSION="@\\"#{s.version}\\"" BITHOCKEY_C_VERSION="\\"#{s.version}\\"" BITHOCKEY_BUILD="@\\"38\\"" BITHOCKEY_C_BUILD="\\"38\\""} }
+  s.subspec 'CrashOnlyLib' do |ss|
+    ss.resource_bundle = { 'HockeySDKResources' => ['Resources/*.lproj'] }
+    ss.vendored_frameworks = 'HockeySDK-iOS/HockeySDKCrashOnly/HockeySDK.framework'
   end
-  
-  s.subspec 'CrashReporter' do |ss|
-    ss.dependency 'HockeySDK/SharedRequirements'
-    ss.ios.vendored_frameworks = 'Vendor/CrashReporter.framework'
-    ss.frameworks = 'SystemConfiguration'
-    ss.source_files = 'Classes/BITCrash*.{h,m}', 'Classes/BITHockeyAttachment.{h,m}'
-    ss.xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS' => %{$(inherited) HOCKEYSDK_FEATURE_CRASH_REPORTER=1} }
-  end
-  
-  s.subspec 'UserFeedback' do |ss|
-    ss.dependency 'HockeySDK/SharedRequirements'
-    ss.frameworks = 'AssetsLibrary', 'MobileCoreServices', 'QuickLook', 'CoreText'
-    ss.source_files = 'Classes/BITFeedback*.{h,m}', 'Classes/BIT*ImageAnnotation.{h,m}', 'Classes/BITImageAnnotationViewController.{h,m}', 'Classes/BITHockeyAttachment.{h,m}', 'Classes/BITHockeyBaseViewController.{h,m}', 'Classes/BITAttributedLabel.{h,m}', 'Classes/BITActivityIndicatorButton.{h,m}'
-    ss.xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS' => %{$(inherited) HOCKEYSDK_FEATURE_FEEDBACK=1} }
-  end
-  
-  s.subspec 'StoreUpdates' do |ss|
-    ss.dependency 'HockeySDK/SharedRequirements'
-    ss.source_files = 'Classes/BITStoreUpdate*.{h,m}'
-    ss.xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS' => %{$(inherited) HOCKEYSDK_FEATURE_STORE_UPDATES=1} }
-  end
-  
-  s.subspec 'Authenticator' do |ss|
-    ss.dependency 'HockeySDK/SharedRequirements'
-    ss.source_files = 'Classes/BITAuthentica*.{h,m}', 'Classes/BITHockeyBaseViewController.{h,m}' 
-    ss.xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS' => %{$(inherited) HOCKEYSDK_FEATURE_AUTHENTICATOR=1} }
-  end
-  
-  s.subspec 'AdHocUpdates' do |ss|
-    ss.dependency 'HockeySDK/SharedRequirements'
-    ss.source_files = 'Classes/BITUpdate*.{h,m}', 'Classes/BITAppVersionMetaInfo.{h,m}', 'Classes/BITHockeyBaseViewController.{h,m}', 'Classes/BITStoreButton.{h,m}', 'Classes/BITAppStoreHeader.{h,m}', 'Classes/BITWebTableViewCell.{h,m}'
-    ss.xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS' => %{$(inherited) HOCKEYSDK_FEATURE_UPDATES=1} }
-  end
-  
-  s.subspec 'CompiledLib' do |ss|
-    ss.dependency 'HockeySDK/CrashReporter'
-    ss.dependency 'HockeySDK/UserFeedback'
-    ss.dependency 'HockeySDK/StoreUpdates'
-    ss.dependency 'HockeySDK/Authenticator'
-    ss.dependency 'HockeySDK/AdHocUpdates'
+
+  s.subspec 'AllFeaturesLib' do |ss|
+    ss.resource_bundle = { 'HockeySDKResources' => ['Resources/*.png', 'Resources/*.lproj'] }
+
+    ss.frameworks = 'CoreGraphics', 'QuartzCore', 'AssetsLibrary', 'MobileCoreServices', 'QuickLook', 'CoreText'
+    ss.vendored_frameworks = 'HockeySDK-iOS/HockeySDK.embeddedframework/HockeySDK.framework'
   end
 
 end

--- a/README.md
+++ b/README.md
@@ -161,10 +161,37 @@ Note that this also means that you can't use the `@import` syntax mentioned in t
 
 **Podfile**
 
-```ruby
-platform :ios, '8.0'
-pod "HockeySDK"
-```
+    ```ruby
+    platform :ios, '8.0'
+    pod "HockeySDK"
+    ```
+
+#### 3.2.1 Binary Distribution Options
+
+The default and recommended distribution is a binary (static library) and a resource bundle with translations and images for all SDK Features: Crash Reporting, User Feedback, Store Updates, Authentication, AdHoc Updates.
+
+You can alternative use a Crash Reporting build only by using the following line in your `Podfile`:
+
+    ```ruby
+    pod "HockeySDK", :subspecs => ['CrashOnlyLib']
+    ```
+
+#### 3.2.2 Source Integration Options
+
+Alternatively you can integrate the SDK by source if you want to do any modifications or want a different feature set. The following entry will integrate all features:
+
+     ```ruby
+    pod "HockeySDK-Source"
+    ```
+
+You can use `subspecs` to specify your own feature set using the following options: `CrashReporter`, `UserFeedback`, `StoreUpdates`, `Authenticator`, `AdHocUpdates`. An example could look like:
+
+    ```ruby
+    pod "HockeySDK-Source", :subspecs => ['CrashReporter', 'UserFeedback']
+    ```
+
+*Note:* The source will not build without warnings in Xcode 7!
+
 
 <a id="extensions"></a>
 ### 3.3 iOS 8 Extensions

--- a/docs/Guide-Installation-Setup-template.md
+++ b/docs/Guide-Installation-Setup-template.md
@@ -117,7 +117,7 @@ If you are working with an older project which doesn't support clang modules yet
 4. Expand `Link Binary With Libraries`.
 5. Add the following system frameworks, if they are missing:
 
-    1. Full feature build: 
+    1. Full Featured: 
         - `AssetsLibrary`
         - `CoreText`
         - `CoreGraphics`
@@ -129,7 +129,7 @@ If you are working with an older project which doesn't support clang modules yet
 	    - `SystemConfiguration`
 	    - `UIKit`
 	    - `libc++`
-	 2. Crash reporting build only:
+	 2. Crash reporting only:
    		- `Foundation`
     	- `Security`
     	- `SystemConfiguration`
@@ -145,10 +145,37 @@ Note that this also means that you can't use the `@import` syntax mentioned in t
 
 **Podfile**
 
-```ruby
-platform :ios, '8.0'
-pod "HockeySDK"
-```
+    ```ruby
+    platform :ios, '8.0'
+    pod "HockeySDK"
+    ```
+
+#### 3.2.1 Binary Distribution Options
+
+The default and recommended distribution is a binary (static library) and a resource bundle with translations and images for all SDK Features: Crash Reporting, User Feedback, Store Updates, Authentication, AdHoc Updates.
+
+You can alternative use a Crash Reporting build only by using the following line in your `Podfile`:
+
+    ```ruby
+    pod "HockeySDK", :subspecs => ['CrashOnlyLib']
+    ```
+
+#### 3.2.2 Source Integration Options
+
+Alternatively you can integrate the SDK by source if you want to do any modifications or want a different feature set. The following entry will integrate all features:
+
+     ```ruby
+    pod "HockeySDK-Source"
+    ```
+
+You can use `subspecs` to specify your own feature set using the following options: `CrashReporter`, `UserFeedback`, `StoreUpdates`, `Authenticator`, `AdHocUpdates`. An example could look like:
+
+    ```ruby
+    pod "HockeySDK-Source", :subspecs => ['CrashReporter', 'UserFeedback']
+    ```
+
+*Note:* The source will not build without warnings in Xcode 7!
+
 
 <a id="extensions"></a>
 ### 3.3 iOS 8 Extensions


### PR DESCRIPTION
- Continue from https://github.com/bitstadium/HockeySDK-iOS/pull/155
- Provide 2 specs, binary based (default) and source based
- Binary based: default subspec `AllFeaturesLib` with all features, additional subspec with crash only `CrashOnlyLib`
- Source based: default subspec with all features `AllFeatures`, additional subspecs for every feature: `CrashReporter`, `UserFeedback`, `StoreUpdates`, `Authenticator`, `AdHocUpdates`