### PR TITLE
Provide proper stack trace for C++ crashes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: objective-c
+osx_image: beta-xcode6.3
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ env:
 before_install:
   - gem install cocoapods --no-rdoc --no-ri --no-document --quiet
   - gem install xcpretty --no-rdoc --no-ri --no-document --quiet
+  - brew tap homebrew/versions
+  - brew install appledoc22
+  - brew link --force appledoc22
 
 script:
   - set -o pipefail

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,11 @@ env:
     - CONFIGURATION="DEBUG"
 
   matrix:
-    - SCHEME="HockeySDK"             DESTINATION="OS=7.0.3,name=iPad 2"                 RUN_TESTS="YES"
+    - SCHEME="HockeySDK"             DESTINATION="OS=7.1,name=iPad 2"                 RUN_TESTS="YES"
     - SCHEME="HockeySDK"             DESTINATION="OS=7.1,name=iPhone 5"                 RUN_TESTS="YES"
-    - SCHEME="HockeySDK"             DESTINATION="OS=8.1,name=iPhone 6"                 RUN_TESTS="YES"
-    - SCHEME="HockeySDK"             DESTINATION="OS=8.1,name=iPhone 6 Plus"            RUN_TESTS="YES"
+    - SCHEME="HockeySDK"             DESTINATION="OS=8.1,name=iPad Air"                 RUN_TESTS="YES"
+    - SCHEME="HockeySDK"             DESTINATION="OS=8.2,name=iPhone 6"                 RUN_TESTS="YES"
+    - SCHEME="HockeySDK"             DESTINATION="OS=8.3,name=iPhone 6 Plus"            RUN_TESTS="YES"
     - SCHEME="HockeySDK Framework"   DESTINATION="platform=iOS Simulator,name=iPhone 6" RUN_TESTS="YES"
     - SCHEME="HockeySDK Distribution"                                                   RUN_TESTS="NO"
 

--- a/Classes/BITCrashCXXExceptionHandler.mm
+++ b/Classes/BITCrashCXXExceptionHandler.mm
@@ -39,112 +39,194 @@
 #import <libkern/OSAtomic.h>
 
 typedef std::vector<BITCrashUncaughtCXXExceptionHandler> BITCrashUncaughtCXXExceptionHandlerList;
+typedef struct
+{
+    void *exception_object;
+    uintptr_t call_stack[128];
+    uint32_t num_frames;
+} BITCrashCXXExceptionTSInfo;
 
 static bool _BITCrashIsOurTerminateHandlerInstalled = false;
 static std::terminate_handler _BITCrashOriginalTerminateHandler = nullptr;
 static BITCrashUncaughtCXXExceptionHandlerList _BITCrashUncaughtExceptionHandlerList;
 static OSSpinLock _BITCrashCXXExceptionHandlingLock = OS_SPINLOCK_INIT;
+static pthread_key_t _BITCrashCXXExceptionInfoTSDKey = 0;
 
 @implementation BITCrashUncaughtCXXExceptionHandlerManager
+
+extern "C" void LIBCXXABI_NORETURN __cxxabiv1::__cxa_throw(void *exception_object, std::type_info *tinfo, void (*dest)(void *))
+{
+  // Purposely do not take a lock in this function. The aim is to be as fast as
+  // possible. While we could really use some of the info set up by the real
+  // __cxa_throw, if we call through we never get control back - the function is
+  // noreturn and jumps to landing pads. Most of the stuff in __cxxabiv1 also
+  // won't work yet. We therefore have to do these checks by hand.
+  
+  // This technique for distinguishing Objective-C exceptions is based on the
+  // implementation of objc_exception_throw(). It's weird, but it's fast. The
+  // weak import and NULL checks should guard against the implementation
+  // changing in a future version.
+  extern const void WEAK_IMPORT_ATTRIBUTE *objc_ehtype_vtable[];
+  if (tinfo && objc_ehtype_vtable && // Guard from an ABI change
+      *reinterpret_cast<void **>(tinfo) == objc_ehtype_vtable + 2) {
+    goto callthrough;
+  }
+  
+  // Any other exception that came here has to be C++, since Objective-C is the
+  // only (known) runtime that hijacks the C++ ABI this way. We need to save off
+  // a backtrace.
+  // Invariant: If the terminate handler is installed, the TSD key must also be
+  // initialized.
+  if (_BITCrashIsOurTerminateHandlerInstalled) {
+    BITCrashCXXExceptionTSInfo *info = static_cast<BITCrashCXXExceptionTSInfo *>(pthread_getspecific(_BITCrashCXXExceptionInfoTSDKey));
+      
+    if (!info) {
+      info = reinterpret_cast<BITCrashCXXExceptionTSInfo *>(calloc(1, sizeof(BITCrashCXXExceptionTSInfo)));
+      pthread_setspecific(_BITCrashCXXExceptionInfoTSDKey, info);
+    }
+    info->exception_object = exception_object;
+    // XXX: All significant time in this call is spent right here.
+    info->num_frames = backtrace(reinterpret_cast<void **>(&info->call_stack[0]), sizeof(info->call_stack) / sizeof(info->call_stack[0]));
+  }
+  
+callthrough:
+  typedef void (*cxa_throw_func)(void *, std::type_info *, void (*)(void *)) LIBCXXABI_NORETURN;
+  static dispatch_once_t predicate = 0;
+  static cxa_throw_func __original__cxa_throw = nullptr;
+
+  dispatch_once(&predicate, ^ {
+    __original__cxa_throw = reinterpret_cast<cxa_throw_func>(dlsym(RTLD_NEXT, "__cxa_throw"));
+  });
+  if (__original__cxa_throw) {
+    __original__cxa_throw(exception_object, tinfo, dest);
+  } else {
+    abort();
+  }
+  __builtin_unreachable();
+}
 
 __attribute__((always_inline))
 static inline void BITCrashIterateExceptionHandlers_unlocked(const BITCrashUncaughtCXXExceptionInfo &info)
 {
-    for (const auto &handler : _BITCrashUncaughtExceptionHandlerList) {
-        handler(&info);
-    }
+  for (const auto &handler : _BITCrashUncaughtExceptionHandlerList) {
+      handler(&info);
+  }
 }
 
 static void BITCrashUncaughtCXXTerminateHandler(void)
 {
-    BITCrashUncaughtCXXExceptionInfo info = {
-        .exception = nullptr,
-        .exception_type_name = nullptr,
-        .exception_message = nullptr,
-        .exception_frames_count = 0,
-        .exception_frames = nullptr,
-    };
-    auto p = std::current_exception();
-    
-    OSSpinLockLock(&_BITCrashCXXExceptionHandlingLock); {
-      if (p) { // explicit operator bool
-          info.exception = reinterpret_cast<const void *>(&p);
-          info.exception_type_name = __cxxabiv1::__cxa_current_exception_type()->name();
-        
-          void *frames[128] = { nullptr };
-        
-          info.exception_frames_count = backtrace(&frames[0], sizeof(frames) / sizeof(frames[0])) - 1;
-          info.exception_frames = reinterpret_cast<uintptr_t *>(&frames[1]);
-        
-          try {
-              std::rethrow_exception(p);
-          } catch (const std::exception &e) { // C++ exception.
-              info.exception_message = e.what();
-              BITCrashIterateExceptionHandlers_unlocked(info);
-          } catch (const std::exception *e) { // C++ exception by pointer.
-              info.exception_message = e->what();
-              BITCrashIterateExceptionHandlers_unlocked(info);
-          } catch (const std::string &e) { // C++ string as exception.
-              info.exception_message = e.c_str();
-              BITCrashIterateExceptionHandlers_unlocked(info);
-          } catch (const std::string *e) { // C++ string pointer as exception.
-              info.exception_message = e->c_str();
-              BITCrashIterateExceptionHandlers_unlocked(info);
-          } catch (const char *e) { // Plain string as exception.
-              info.exception_message = e;
-              BITCrashIterateExceptionHandlers_unlocked(info);
-          } catch (id e) { // Objective-C exception. Pass it on to Foundation.
-              OSSpinLockUnlock(&_BITCrashCXXExceptionHandlingLock);
-              if (_BITCrashOriginalTerminateHandler != nullptr) {
-                  _BITCrashOriginalTerminateHandler();
-              }
-              return;
-          } catch (...) { // Any other kind of exception. No message.
-              BITCrashIterateExceptionHandlers_unlocked(info);
-          }
-      }
-    } OSSpinLockUnlock(&_BITCrashCXXExceptionHandlingLock); // In case terminate is called reentrantly by pasing it on
+  BITCrashUncaughtCXXExceptionInfo info = {
+    .exception = nullptr,
+    .exception_type_name = nullptr,
+    .exception_message = nullptr,
+    .exception_frames_count = 0,
+    .exception_frames = nullptr,
+  };
+  auto p = std::current_exception();
   
-    if (_BITCrashOriginalTerminateHandler != nullptr) {
-        _BITCrashOriginalTerminateHandler();
-    } else {
-        abort();
+  OSSpinLockLock(&_BITCrashCXXExceptionHandlingLock); {
+    if (p) { // explicit operator bool
+      info.exception = reinterpret_cast<const void *>(&p);
+      info.exception_type_name = __cxxabiv1::__cxa_current_exception_type()->name();
+      
+      BITCrashCXXExceptionTSInfo *recorded_info = reinterpret_cast<BITCrashCXXExceptionTSInfo *>(pthread_getspecific(_BITCrashCXXExceptionInfoTSDKey));
+      
+      if (recorded_info) {
+        if (__cxxabiv1::__cxa_current_primary_exception() != recorded_info->exception_object) {
+#if DEBUG
+          fprintf(stderr, "HockeyApp: Warning - using the backtrace from a non-matching C++ exception!\n");
+#endif
+        }
+        info.exception_frames_count = recorded_info->num_frames - 1;
+        info.exception_frames = &recorded_info->call_stack[1];
+      } else {
+        // There's no backtrace, grab this function's trace instead.
+#if DEBUG
+        fprintf(stderr, "HockeyApp: Warning - no backtrace available, where did this exception come from?\n");
+#endif
+        void *frames[128] = { nullptr };
+      
+        info.exception_frames_count = backtrace(&frames[0], sizeof(frames) / sizeof(frames[0])) - 1;
+        info.exception_frames = reinterpret_cast<uintptr_t *>(&frames[1]);
+      }
+      
+      try {
+        std::rethrow_exception(p);
+      } catch (const std::exception &e) { // C++ exception.
+        info.exception_message = e.what();
+        BITCrashIterateExceptionHandlers_unlocked(info);
+      } catch (const std::exception *e) { // C++ exception by pointer.
+        info.exception_message = e->what();
+        BITCrashIterateExceptionHandlers_unlocked(info);
+      } catch (const std::string &e) { // C++ string as exception.
+        info.exception_message = e.c_str();
+        BITCrashIterateExceptionHandlers_unlocked(info);
+      } catch (const std::string *e) { // C++ string pointer as exception.
+        info.exception_message = e->c_str();
+        BITCrashIterateExceptionHandlers_unlocked(info);
+      } catch (const char *e) { // Plain string as exception.
+        info.exception_message = e;
+        BITCrashIterateExceptionHandlers_unlocked(info);
+      } catch (id e) { // Objective-C exception. Pass it on to Foundation.
+        OSSpinLockUnlock(&_BITCrashCXXExceptionHandlingLock);
+        if (_BITCrashOriginalTerminateHandler != nullptr) {
+          _BITCrashOriginalTerminateHandler();
+        }
+        return;
+      } catch (...) { // Any other kind of exception. No message.
+        BITCrashIterateExceptionHandlers_unlocked(info);
+      }
     }
+  } OSSpinLockUnlock(&_BITCrashCXXExceptionHandlingLock); // In case terminate is called reentrantly by pasing it on
+
+  if (_BITCrashOriginalTerminateHandler != nullptr) {
+    _BITCrashOriginalTerminateHandler();
+  } else {
+    abort();
+  }
 }
 
 + (void)addCXXExceptionHandler:(BITCrashUncaughtCXXExceptionHandler)handler
 {
-    OSSpinLockLock(&_BITCrashCXXExceptionHandlingLock); {
-        if (!_BITCrashIsOurTerminateHandlerInstalled) {
-            _BITCrashOriginalTerminateHandler = std::set_terminate(BITCrashUncaughtCXXTerminateHandler);
-            _BITCrashIsOurTerminateHandlerInstalled = true;
-        }
-        _BITCrashUncaughtExceptionHandlerList.push_back(handler);
-    } OSSpinLockUnlock(&_BITCrashCXXExceptionHandlingLock);
+  static dispatch_once_t key_predicate = 0;
+  
+  // This only EVER has to be done once, since we don't delete the TSD later
+  // (there's no reason to delete it).
+  dispatch_once(&key_predicate, ^ {
+    pthread_key_create(&_BITCrashCXXExceptionInfoTSDKey, free);
+  });
+
+  OSSpinLockLock(&_BITCrashCXXExceptionHandlingLock); {
+    if (!_BITCrashIsOurTerminateHandlerInstalled) {
+      _BITCrashOriginalTerminateHandler = std::set_terminate(BITCrashUncaughtCXXTerminateHandler);
+      _BITCrashIsOurTerminateHandlerInstalled = true;
+    }
+    _BITCrashUncaughtExceptionHandlerList.push_back(handler);
+  } OSSpinLockUnlock(&_BITCrashCXXExceptionHandlingLock);
 }
 
 + (void)removeCXXExceptionHandler:(BITCrashUncaughtCXXExceptionHandler)handler
 {
-    OSSpinLockLock(&_BITCrashCXXExceptionHandlingLock); {
-        auto i = std::find(_BITCrashUncaughtExceptionHandlerList.begin(), _BITCrashUncaughtExceptionHandlerList.end(), handler);
-      
-        if (i != _BITCrashUncaughtExceptionHandlerList.end()) {
-          _BITCrashUncaughtExceptionHandlerList.erase(i);
+  OSSpinLockLock(&_BITCrashCXXExceptionHandlingLock); {
+    auto i = std::find(_BITCrashUncaughtExceptionHandlerList.begin(), _BITCrashUncaughtExceptionHandlerList.end(), handler);
+  
+    if (i != _BITCrashUncaughtExceptionHandlerList.end()) {
+      _BITCrashUncaughtExceptionHandlerList.erase(i);
+    }
+
+    if (_BITCrashIsOurTerminateHandlerInstalled) {
+      if (_BITCrashUncaughtExceptionHandlerList.empty()) {
+        std::terminate_handler previous_handler = std::set_terminate(_BITCrashOriginalTerminateHandler);
+        
+        if (previous_handler != BITCrashUncaughtCXXTerminateHandler) {
+          std::set_terminate(previous_handler);
+        } else {
+          _BITCrashIsOurTerminateHandlerInstalled = false;
+          _BITCrashOriginalTerminateHandler = nullptr;
         }
-    
-        if (_BITCrashIsOurTerminateHandlerInstalled) {
-            if (_BITCrashUncaughtExceptionHandlerList.empty()) {
-                std::terminate_handler previous_handler = std::set_terminate(_BITCrashOriginalTerminateHandler);
-                
-                if (previous_handler != BITCrashUncaughtCXXTerminateHandler) {
-                    std::set_terminate(previous_handler);
-                } else {
-                    _BITCrashIsOurTerminateHandlerInstalled = false;
-                    _BITCrashOriginalTerminateHandler = nullptr;
-                }
-            }
-        }
-    } OSSpinLockUnlock(&_BITCrashCXXExceptionHandlingLock);
+      }
+    }
+  } OSSpinLockUnlock(&_BITCrashCXXExceptionHandlingLock);
 }
 
 @end

--- a/Classes/BITCrashCXXExceptionHandler.mm
+++ b/Classes/BITCrashCXXExceptionHandler.mm
@@ -104,7 +104,10 @@ callthrough:
   } else {
     abort();
   }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunreachable-code"
   __builtin_unreachable();
+#pragma clang diagnostic pop
 }
 
 __attribute__((always_inline))

--- a/Classes/BITCrashManager.m
+++ b/Classes/BITCrashManager.m
@@ -103,18 +103,7 @@ static PLCrashReporterCallbacks plCrashCallbacks = {
 // Temporary class until PLCR catches up
 // We trick PLCR with an Objective-C exception.
 //
-// This code provides us access to the C++ exception message, but we won't get a correct stack trace.
-// The cause for this is that the iOS runtime catches every C++ exception internally and rethrows it.
-// Since the exception object doesn't have the backtrace attached, we have no chance of accessing it.
-//
-// As a workaround we could hook into __cxx_throw and attaching the backtrace every time this is called.
-// This has a few sides effects which is why we are not doing this right now:
-// - CoreAdudio (and possibly other frameworks) use C++ exceptions heavily for control flow.
-//   Calling `backtrace()` is not cheap, so this could affect performance
-// - It is not clear if such a hook is ABI compatible with all C++ runtimes
-// - It is not clear if there could be any other side effects
-//
-// We'll evaluate this further to see if there is a safe solution.
+// This code provides us access to the C++ exception message, including a correct stack trace.
 //
 @interface BITCrashCXXExceptionWrapperException : NSException
 - (instancetype)initWithCXXExceptionInfo:(const BITCrashUncaughtCXXExceptionInfo *)info;

--- a/Support/HockeySDK.xcodeproj/project.pbxproj
+++ b/Support/HockeySDK.xcodeproj/project.pbxproj
@@ -469,6 +469,7 @@
 		1E84DB3317E0977C00AC83FD /* HockeySDKFeatureConfig.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HockeySDKFeatureConfig.h; sourceTree = "<group>"; };
 		1E85C5601B3438E000CE2C0D /* live_report_exception_marketing.plcrash */ = {isa = PBXFileReference; lastKnownFileType = file; path = live_report_exception_marketing.plcrash; sourceTree = "<group>"; };
 		1E85C5611B3438E000CE2C0D /* live_report_signal_marketing.plcrash */ = {isa = PBXFileReference; lastKnownFileType = file; path = live_report_signal_marketing.plcrash; sourceTree = "<group>"; };
+		1E85C5A11B35BD7000CE2C0D /* module_crashonly.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module_crashonly.modulemap; sourceTree = "<group>"; };
 		1E90D97A19DAD8A800188C43 /* feedbackActivity.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = feedbackActivity.png; sourceTree = "<group>"; };
 		1E90D97B19DAD8A800188C43 /* feedbackActivity@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "feedbackActivity@2x.png"; sourceTree = "<group>"; };
 		1E90D97C19DAD8A800188C43 /* feedbackActivity@2x~ipad.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "feedbackActivity@2x~ipad.png"; sourceTree = "<group>"; };
@@ -709,6 +710,7 @@
 				1E754DC61621BC170070AB92 /* HockeySDK.xcconfig */,
 				1E66CA9115D4100500F35BED /* buildnumber.xcconfig */,
 				1E7DE39619D44DC6009AB8E5 /* crashonly.xcconfig */,
+				1E85C5A11B35BD7000CE2C0D /* module_crashonly.modulemap */,
 				1E91D84619B924E600E9616D /* module.modulemap */,
 			);
 			name = Support;

--- a/Support/HockeySDKTests/BITTestHelper.m
+++ b/Support/HockeySDKTests/BITTestHelper.m
@@ -67,7 +67,7 @@
   // the bundle identifier when running with unit tets is "otest"
   const char *progname = getprogname();
   if (progname == NULL) {
-    return NO;
+    return nil;
   }
 
   NSString *filePath = [[NSBundle bundleForClass:self.class] pathForResource:filename ofType:@"plcrash"];


### PR DESCRIPTION
This only works if the c++ crash happens in the main binary, but doesn't work yet if the crash happens in a dynamic framework