### PR TITLE
Remove @param documentation command used with a property, not a method/function

### DIFF
--- a/Classes/BITFeedbackManager.h
+++ b/Classes/BITFeedbackManager.h
@@ -228,7 +228,6 @@ typedef NS_ENUM(NSInteger, BITFeedbackObservationMode) {
  All NSString-Content in the array will be concatenated and result in the message,
  while all UIImage and NSData-instances will be turned into attachments.
  
- @param items an NSArray with objects that should be attached
  @see `[BITFeedbackComposeViewController prepareWithItems:]`
  */
 @property (nonatomic, copy) NSArray *feedbackComposerPreparedItems;


### PR DESCRIPTION
This was causing the following error to be shown in Xcode when `-Wdocumentation` is enabled:

```
BITFeedbackManager.h:231:3: '@param' command used in a comment that is not attached to a function declaration
```