### PR TITLE
Make sure we don't add images to final report twice

### DIFF
--- a/Classes/BITCrashReportTextFormatter.m
+++ b/Classes/BITCrashReportTextFormatter.m
@@ -539,7 +539,15 @@ static const char *findSEL (const char *imageName, NSString *imageUUID, uint64_t
   
   /* Images. The iPhone crash report format sorts these in ascending order, by the base address */
   [text appendString: @"Binary Images:\n"];
+  NSMutableArray *addedImagesBaseAddresses = @[].mutableCopy;
   for (BITPLCrashReportBinaryImageInfo *imageInfo in [report.images sortedArrayUsingFunction: bit_binaryImageSort context: nil]) {
+    // Make sure we don't add duplicates
+    if ([addedImagesBaseAddresses containsObject:@(imageInfo.imageBaseAddress)]) {
+      continue;
+    } else {
+      [addedImagesBaseAddresses addObject:@(imageInfo.imageBaseAddress)];
+    }
+    
     NSString *uuid;
     /* Fetch the UUID if it exists */
     if (imageInfo.hasImageUUID)


### PR DESCRIPTION
This is to prevent issues with PLCR under iOS 9, see here: https://groups.google.com/forum/#!msg/plcrashreporter/i6rYc2f4yBo/G8uBTEnMAgAJ
