### PR TITLE
Update AppStore detection

### DIFF
--- a/Classes/BITAuthenticator.m
+++ b/Classes/BITAuthenticator.m
@@ -83,7 +83,7 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
 #pragma mark - BITHockeyBaseManager overrides
 - (void)startManager {
   //disabled in TestFlight and the AppStore
-  if([self isTestFlightEnvironment] || [self isAppStoreEnvironment]) return;
+  if(self.appEnvironment != BITEnvironmentOther) return;
   
   _isSetup = YES;
 }
@@ -110,7 +110,7 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
 
 - (void)authenticateInstallation {
   //disabled in TestFlight and the AppStore
-  if([self isTestFlightEnvironment] || [self isAppStoreEnvironment]) return;
+  if(self.appEnvironment != BITEnvironmentOther) return;
   
   // make sure this is called after startManager so all modules are fully setup
   if (!_isSetup) {

--- a/Classes/BITAuthenticator.m
+++ b/Classes/BITAuthenticator.m
@@ -67,8 +67,8 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
   [self unregisterObservers];
 }
 
-- (instancetype) initWithAppIdentifier:(NSString *)appIdentifier isAppStoreEnvironment:(BOOL)isAppStoreEnvironment {
-  self = [super initWithAppIdentifier:appIdentifier isAppStoreEnvironment:isAppStoreEnvironment];
+- (instancetype)initWithAppIdentifier:(NSString *)appIdentifier isTestFlightEnvironment:(BOOL)isTestFlightEnvironment isAppStoreEnvironment:(BOOL)isAppStoreEnvironment {
+  self = [super initWithAppIdentifier:appIdentifier isTestFlightEnvironment:isTestFlightEnvironment isAppStoreEnvironment:isAppStoreEnvironment];
   if( self ) {
     _webpageURL = [NSURL URLWithString:@"https://rink.hockeyapp.net/"];
     
@@ -82,8 +82,8 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
 
 #pragma mark - BITHockeyBaseManager overrides
 - (void)startManager {
-  //disabled in the appStore
-  if([self isAppStoreEnvironment]) return;
+  //disabled in TestFlight and the AppStore
+  if([self isTestFlightEnvironment] || [self isAppStoreEnvironment]) return;
   
   _isSetup = YES;
 }
@@ -109,8 +109,8 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
 }
 
 - (void)authenticateInstallation {
-  //disabled in the appStore
-  if([self isAppStoreEnvironment]) return;
+  //disabled in TestFlight and the AppStore
+  if([self isTestFlightEnvironment] || [self isAppStoreEnvironment]) return;
   
   // make sure this is called after startManager so all modules are fully setup
   if (!_isSetup) {

--- a/Classes/BITAuthenticator.m
+++ b/Classes/BITAuthenticator.m
@@ -67,8 +67,8 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
   [self unregisterObservers];
 }
 
-- (instancetype)initWithAppIdentifier:(NSString *)appIdentifier isTestFlightEnvironment:(BOOL)isTestFlightEnvironment isAppStoreEnvironment:(BOOL)isAppStoreEnvironment {
-  self = [super initWithAppIdentifier:appIdentifier isTestFlightEnvironment:isTestFlightEnvironment isAppStoreEnvironment:isAppStoreEnvironment];
+- (instancetype)initWithAppIdentifier:(NSString *)appIdentifier appEnvironment:(BITEnvironment)environment {
+  self = [super initWithAppIdentifier:appIdentifier appEnvironment:environment];
   if( self ) {
     _webpageURL = [NSURL URLWithString:@"https://rink.hockeyapp.net/"];
     

--- a/Classes/BITCrashManager.m
+++ b/Classes/BITCrashManager.m
@@ -728,7 +728,7 @@ static void uncaught_cxx_exception_handler(const BITCrashUncaughtCXXExceptionInf
 
 
 - (void)generateTestCrash {
-  if (![self isAppStoreEnvironment]) {
+  if (self.appEnvironment == BITEnvironmentOther) {
     
     if ([self isDebuggerAttached]) {
       NSLog(@"[HockeySDK] WARNING: The debugger is attached. The following crash cannot be detected by the SDK!");
@@ -1158,7 +1158,7 @@ static void uncaught_cxx_exception_handler(const BITCrashUncaughtCXXExceptionInf
       // We only check for this if we are not in the App Store environment
       
       BOOL debuggerIsAttached = NO;
-      if (![self isAppStoreEnvironment]) {
+      if (self.appEnvironment != BITEnvironmentAppStore) {
         if ([self isDebuggerAttached]) {
           debuggerIsAttached = YES;
           NSLog(@"[HockeySDK] WARNING: Detecting crashes is NOT enabled due to running the app with a debugger attached.");

--- a/Classes/BITHockeyBaseManager.m
+++ b/Classes/BITHockeyBaseManager.m
@@ -75,11 +75,20 @@
   return self;
 }
 
-- (instancetype)initWithAppIdentifier:(NSString *)appIdentifier isTestFlightEnvironment:(BOOL)isTestFlightEnvironment isAppStoreEnvironment:(BOOL)isAppStoreEnvironment {
+- (instancetype)initWithAppIdentifier:(NSString *)appIdentifier appEnvironment:(BITEnvironment)environment {
   if ((self = [self init])) {
     _appIdentifier = appIdentifier;
-    _testFlightEnvironment = isTestFlightEnvironment;
-    _appStoreEnvironment = isAppStoreEnvironment;
+    _appStoreEnvironment = NO;
+    _testFlightEnvironment = NO;
+    switch (environment) {
+      case BITEnvironmentAppStore:
+        _appStoreEnvironment = YES;
+        break;
+      case BITEnvironmentTestFlight:
+        _testFlightEnvironment = YES;
+      default:
+        break;
+    }
   }
   return self;
 }

--- a/Classes/BITHockeyBaseManager.m
+++ b/Classes/BITHockeyBaseManager.m
@@ -51,8 +51,6 @@
   UINavigationController *_navController;
   
   NSDateFormatter *_rfc3339Formatter;
-  
-  BOOL _isAppStoreEnvironment;
 }
 
 
@@ -77,10 +75,11 @@
   return self;
 }
 
-- (instancetype)initWithAppIdentifier:(NSString *)appIdentifier isAppStoreEnvironment:(BOOL)isAppStoreEnvironment {
+- (instancetype)initWithAppIdentifier:(NSString *)appIdentifier isTestFlightEnvironment:(BOOL)isTestFlightEnvironment isAppStoreEnvironment:(BOOL)isAppStoreEnvironment {
   if ((self = [self init])) {
     _appIdentifier = appIdentifier;
-    _isAppStoreEnvironment = isAppStoreEnvironment;
+    _testFlightEnvironment = isTestFlightEnvironment;
+    _appStoreEnvironment = isAppStoreEnvironment;
   }
   return self;
 }
@@ -90,10 +89,6 @@
 
 - (void)reportError:(NSError *)error {
   BITHockeyLog(@"ERROR: %@", [error localizedDescription]);
-}
-
-- (BOOL)isAppStoreEnvironment {
-  return _isAppStoreEnvironment;
 }
 
 - (NSString *)encodedAppIdentifier {

--- a/Classes/BITHockeyBaseManager.m
+++ b/Classes/BITHockeyBaseManager.m
@@ -78,17 +78,7 @@
 - (instancetype)initWithAppIdentifier:(NSString *)appIdentifier appEnvironment:(BITEnvironment)environment {
   if ((self = [self init])) {
     _appIdentifier = appIdentifier;
-    _appStoreEnvironment = NO;
-    _testFlightEnvironment = NO;
-    switch (environment) {
-      case BITEnvironmentAppStore:
-        _appStoreEnvironment = YES;
-        break;
-      case BITEnvironmentTestFlight:
-        _testFlightEnvironment = YES;
-      default:
-        break;
-    }
+    _appEnvironment = environment;
   }
   return self;
 }

--- a/Classes/BITHockeyBaseManagerPrivate.h
+++ b/Classes/BITHockeyBaseManagerPrivate.h
@@ -40,7 +40,7 @@
 
 @property (nonatomic, assign, readonly, getter=isAppStoreEnvironment) BOOL appStoreEnvironment;
 
-- (instancetype)initWithAppIdentifier:(NSString *)appIdentifier isTestFlightEnvironment:(BOOL)isTestFlightEnvironment isAppStoreEnvironment:(BOOL)isAppStoreEnvironment;
+- (instancetype)initWithAppIdentifier:(NSString *)appIdentifier appEnvironment:(BITEnvironment)environment;
 
 - (void)startManager;
 

--- a/Classes/BITHockeyBaseManagerPrivate.h
+++ b/Classes/BITHockeyBaseManagerPrivate.h
@@ -28,6 +28,7 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
+#import "BITHockeyManager.h"
 
 @class BITHockeyBaseManager;
 @class BITHockeyBaseViewController;
@@ -36,9 +37,7 @@
 
 @property (nonatomic, strong) NSString *appIdentifier;
 
-@property (nonatomic, assign, readonly, getter=isTestFlightEnvironment) BOOL testFlightEnvironment;
-
-@property (nonatomic, assign, readonly, getter=isAppStoreEnvironment) BOOL appStoreEnvironment;
+@property (nonatomic, assign, readonly) BITEnvironment appEnvironment;
 
 - (instancetype)initWithAppIdentifier:(NSString *)appIdentifier appEnvironment:(BITEnvironment)environment;
 

--- a/Classes/BITHockeyBaseManagerPrivate.h
+++ b/Classes/BITHockeyBaseManagerPrivate.h
@@ -36,12 +36,13 @@
 
 @property (nonatomic, strong) NSString *appIdentifier;
 
-- (instancetype)initWithAppIdentifier:(NSString *)appIdentifier isAppStoreEnvironment:(BOOL)isAppStoreEnvironment;
+@property (nonatomic, assign, readonly, getter=isTestFlightEnvironment) BOOL testFlightEnvironment;
+
+@property (nonatomic, assign, readonly, getter=isAppStoreEnvironment) BOOL appStoreEnvironment;
+
+- (instancetype)initWithAppIdentifier:(NSString *)appIdentifier isTestFlightEnvironment:(BOOL)isTestFlightEnvironment isAppStoreEnvironment:(BOOL)isAppStoreEnvironment;
 
 - (void)startManager;
-
-/** the value this object was initialized with */
-- (BOOL)isAppStoreEnvironment;
 
 /** Check if the device is running an iOS version previous to iOS 7 */
 - (BOOL)isPreiOS7Environment;

--- a/Classes/BITHockeyHelper.h
+++ b/Classes/BITHockeyHelper.h
@@ -47,6 +47,10 @@ NSString *bit_UUID(void);
 NSString *bit_appAnonID(BOOL forceNewAnonID);
 BOOL bit_isPreiOS7Environment(void);
 BOOL bit_isPreiOS8Environment(void);
+BOOL bit_isAppStoreReceiptSandbox(void);
+BOOL bit_hasEmbeddedMobileProvision(void);
+BOOL bit_isRunningInTestFlightEnvironment(void);
+BOOL bit_isRunningInAppStoreEnvironment(void);
 BOOL bit_isRunningInAppExtension(void);
 
 #if !defined (HOCKEYSDK_CONFIGURATION_ReleaseCrashOnly) && !defined (HOCKEYSDK_CONFIGURATION_ReleaseCrashOnlyExtensions)

--- a/Classes/BITHockeyHelper.m
+++ b/Classes/BITHockeyHelper.m
@@ -271,6 +271,45 @@ BOOL bit_isPreiOS8Environment(void) {
   return isPreiOS8Environment;
 }
 
+BOOL bit_isAppStoreReceiptSandbox(void) {
+#if TARGET_IPHONE_SIMULATOR
+  return NO;
+#else
+  NSURL *appStoreReceiptURL = NSBundle.mainBundle.appStoreReceiptURL;
+  NSString *appStoreReceiptLastComponent = appStoreReceiptURL.lastPathComponent;
+  
+  BOOL isSandboxReceipt = [appStoreReceiptLastComponent isEqualToString:@"sandboxReceipt"];
+  return isSandboxReceipt;
+#endif
+}
+
+BOOL bit_hasEmbeddedMobileProvision(void) {
+  BOOL hasEmbeddedMobileProvision = [[NSBundle mainBundle] pathForResource:@"embedded" ofType:@"mobileprovision"];
+  return hasEmbeddedMobileProvision;
+}
+
+BOOL bit_isRunningInTestFlightEnvironment(void) {
+#if TARGET_IPHONE_SIMULATOR
+  return NO;
+#else
+  if (bit_isAppStoreReceiptSandbox() && !bit_hasEmbeddedMobileProvision()) {
+    return YES;
+  }
+  return NO;
+#endif
+}
+
+BOOL bit_isRunningInAppStoreEnvironment(void) {
+#if TARGET_IPHONE_SIMULATOR
+  return NO;
+#else
+  if (bit_isAppStoreReceiptSandbox() || bit_hasEmbeddedMobileProvision()) {
+    return NO;
+  }
+  return YES;
+#endif
+}
+
 BOOL bit_isRunningInAppExtension(void) {
   static BOOL isRunningInAppExtension = NO;
   static dispatch_once_t checkAppExtension;

--- a/Classes/BITHockeyManager.h
+++ b/Classes/BITHockeyManager.h
@@ -375,9 +375,21 @@
 /// @name Environment
 ///-----------------------------------------------------------------------------
 
+/**
+ *  HockeySDK App environment
+ */
 typedef NS_ENUM(NSInteger, BITEnvironment) {
+  /**
+   *  App has been downloaded from the AppStore
+   */
   BITEnvironmentAppStore = 0,
+  /**
+   *  App has been downloaded from TestFlight
+   */
   BITEnvironmentTestFlight = 1,
+  /**
+   *  App has been installed by some other mechanism
+   */
   BITEnvironmentOther = 99
 };
 

--- a/Classes/BITHockeyManager.h
+++ b/Classes/BITHockeyManager.h
@@ -396,7 +396,7 @@ typedef NS_ENUM(NSInteger, BITEnvironment) {
  Returns _YES_ if the app is installed and running from the App Store
  Returns _NO_ if the app is installed via debug, ad-hoc or enterprise distribution
  */
-@property (nonatomic, readonly, getter=isAppStoreEnvironment) BOOL appStoreEnvironment;
+@property (nonatomic, readonly, getter=isAppStoreEnvironment) BOOL appStoreEnvironment DEPRECATED_MSG_ATTRIBUTE("Use appEnvironment instead!");
 
 
 /**

--- a/Classes/BITHockeyManager.h
+++ b/Classes/BITHockeyManager.h
@@ -375,6 +375,20 @@
 /// @name Environment
 ///-----------------------------------------------------------------------------
 
+typedef NS_ENUM(NSInteger, BITEnvironment) {
+  BITEnvironmentAppStore = 0,
+  BITEnvironmentTestFlight = 1,
+  BITEnvironmentOther = 99
+};
+
+/**
+ Enum that determines what kind of environment the application is installed and running in.
+ 
+ See `BITEnvironment`
+ */
+@property (nonatomic, readonly) BITEnvironment appEnvironment;
+
+
 /**
  Flag that determines whether the application is installed and running
  from an App Store installation.

--- a/Classes/BITHockeyManager.h
+++ b/Classes/BITHockeyManager.h
@@ -377,9 +377,18 @@
 
 
 /**
- Enum that determines what kind of environment the application is installed and running in.
+ Enum that indicates what kind of environment the application is installed and running in.
  
- See `BITEnvironment`
+ This property can be used to disable or enable specific funtionality 
+ only when specific conditions are met.
+ That could mean for example, to only enable debug UI elements 
+ when the app has been installed over HockeyApp but not in the AppStore.
+ 
+ The underlying enum type at the moment only specifies values for the AppStore,
+ TestFlight and Other. Other summarizes several different distribution methods
+ and we might define additional specifc values for other environments in the future.
+ 
+ @see `BITEnvironment`
  */
 @property (nonatomic, readonly) BITEnvironment appEnvironment;
 

--- a/Classes/BITHockeyManager.h
+++ b/Classes/BITHockeyManager.h
@@ -31,7 +31,7 @@
 #import <UIKit/UIKit.h>
 
 #import "HockeySDKFeatureConfig.h"
-
+#import "HockeySDKEnums.h"
 
 @protocol BITHockeyManagerDelegate;
 
@@ -375,23 +375,6 @@
 /// @name Environment
 ///-----------------------------------------------------------------------------
 
-/**
- *  HockeySDK App environment
- */
-typedef NS_ENUM(NSInteger, BITEnvironment) {
-  /**
-   *  App has been downloaded from the AppStore
-   */
-  BITEnvironmentAppStore = 0,
-  /**
-   *  App has been downloaded from TestFlight
-   */
-  BITEnvironmentTestFlight = 1,
-  /**
-   *  App has been installed by some other mechanism
-   */
-  BITEnvironmentOther = 99
-};
 
 /**
  Enum that determines what kind of environment the application is installed and running in.

--- a/Classes/BITHockeyManager.m
+++ b/Classes/BITHockeyManager.m
@@ -75,6 +75,15 @@ bitstadium_info_t bitstadium_library_info __attribute__((section("__TEXT,__bit_h
 
 @interface BITHockeyManager ()
 
+/**
+ Flag that determines whether the application is installed and running
+ from an App Store installation.
+ 
+ Returns _YES_ if the app is installed and running from the App Store
+ Returns _NO_ if the app is installed via debug, ad-hoc or enterprise distribution
+ */
+@property (nonatomic, readonly, getter=isTestFlightEnvironment) BOOL testFlightEnvironment;
+
 - (BOOL)shouldUseLiveIdentifier;
 
 @end
@@ -156,6 +165,7 @@ bitstadium_info_t bitstadium_library_info __attribute__((section("__TEXT,__bit_h
     _enableStoreUpdateManager = NO;
 #endif
     
+    _testFlightEnvironment = NO;
     _appStoreEnvironment = NO;
     _startManagerIsInvoked = NO;
     _startUpdateManagerIsInvoked = NO;
@@ -166,8 +176,11 @@ bitstadium_info_t bitstadium_library_info __attribute__((section("__TEXT,__bit_h
     
 #if !TARGET_IPHONE_SIMULATOR
     // check if we are really in an app store environment
-    if (![[NSBundle mainBundle] pathForResource:@"embedded" ofType:@"mobileprovision"]) {
+    if (bit_isRunningInAppStoreEnvironment()) {
       _appStoreEnvironment = YES;
+    }
+    if (bit_isRunningInTestFlightEnvironment()) {
+      _testFlightEnvironment = YES;
     }
 #endif
 

--- a/Classes/BITHockeyManager.m
+++ b/Classes/BITHockeyManager.m
@@ -192,7 +192,7 @@ bitstadium_info_t bitstadium_library_info __attribute__((section("__TEXT,__bit_h
 - (void)dealloc {
 #if HOCKEYSDK_FEATURE_AUTHENTICATOR
   // start Authenticator
-  if (![self isAppStoreEnvironment]) {
+  if (self.appEnvironment != BITEnvironmentAppStore) {
     [_authenticator removeObserver:self forKeyPath:@"identified"];
   }
 #endif
@@ -243,7 +243,7 @@ bitstadium_info_t bitstadium_library_info __attribute__((section("__TEXT,__bit_h
   
   if (![self isSetUpOnMainThread]) return;
   
-  if ([self isAppStoreEnvironment] && [self isInstallTrackingDisabled]) {
+  if ((self.appEnvironment == BITEnvironmentAppStore) && [self isInstallTrackingDisabled]) {
     _installString = bit_appAnonID(YES);
   }
 
@@ -299,7 +299,7 @@ bitstadium_info_t bitstadium_library_info __attribute__((section("__TEXT,__bit_h
   
 #if HOCKEYSDK_FEATURE_AUTHENTICATOR
   // start Authenticator
-  if (![self isAppStoreEnvironment]) {
+  if (self.appEnvironment != BITEnvironmentAppStore) {
     // hook into manager with kvo!
     [_authenticator addObserver:self forKeyPath:@"identified" options:0 context:nil];
     
@@ -315,7 +315,7 @@ bitstadium_info_t bitstadium_library_info __attribute__((section("__TEXT,__bit_h
   BOOL isIdentified = NO;
 
 #if HOCKEYSDK_FEATURE_AUTHENTICATOR
-  if (![self isAppStoreEnvironment])
+  if (self.appEnvironment != BITEnvironmentAppStore)
     isIdentified = [self.authenticator isIdentified];
 #endif /* HOCKEYSDK_FEATURE_AUTHENTICATOR */
 
@@ -374,7 +374,7 @@ bitstadium_info_t bitstadium_library_info __attribute__((section("__TEXT,__bit_h
 
 
 - (void)setDelegate:(id<BITHockeyManagerDelegate>)delegate {
-  if (![self isAppStoreEnvironment]) {
+  if (self.appEnvironment != BITEnvironmentAppStore) {
     if (_startManagerIsInvoked) {
       NSLog(@"[HockeySDK] ERROR: The `delegate` property has to be set before calling [[BITHockeyManager sharedHockeyManager] startManager] !");
     }
@@ -466,7 +466,7 @@ bitstadium_info_t bitstadium_library_info __attribute__((section("__TEXT,__bit_h
 }
 
 - (void)testIdentifier {
-  if (!_appIdentifier || [self isAppStoreEnvironment]) {
+  if (!_appIdentifier || (self.appEnvironment == BITEnvironmentAppStore)) {
     return;
   }
   
@@ -495,7 +495,7 @@ bitstadium_info_t bitstadium_library_info __attribute__((section("__TEXT,__bit_h
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
   if ([keyPath isEqualToString:@"identified"] &&
       [object valueForKey:@"isIdentified"] ) {
-    if (![self isAppStoreEnvironment]) {
+    if (self.appEnvironment != BITEnvironmentAppStore) {
       BOOL identified = [(NSNumber *)[object valueForKey:@"isIdentified"] boolValue];
       if (identified && ![self isUpdateManagerDisabled]) {
         [self invokeStartUpdateManager];
@@ -525,7 +525,7 @@ bitstadium_info_t bitstadium_library_info __attribute__((section("__TEXT,__bit_h
 }
 
 - (BOOL)integrationFlowStartedWithTimeString:(NSString *)timeString {
-  if (timeString == nil || [self isAppStoreEnvironment]) {
+  if (timeString == nil || (self.appEnvironment == BITEnvironmentAppStore)) {
     return NO;
   }
   
@@ -543,7 +543,7 @@ bitstadium_info_t bitstadium_library_info __attribute__((section("__TEXT,__bit_h
 }
 
 - (void)pingServerForIntegrationStartWorkflowWithTimeString:(NSString *)timeString appIdentifier:(NSString *)appIdentifier {
-  if (!appIdentifier || [self isAppStoreEnvironment]) {
+  if (!appIdentifier || (self.appEnvironment == BITEnvironmentAppStore)) {
     return;
   }
   
@@ -627,7 +627,7 @@ bitstadium_info_t bitstadium_library_info __attribute__((section("__TEXT,__bit_h
   NSString *errorString = @"ERROR: HockeySDK has to be setup on the main thread!";
   
   if (!NSThread.isMainThread) {
-    if (self.isAppStoreEnvironment) {
+    if (self.appEnvironment == BITEnvironmentAppStore) {
       BITHockeyLog(@"%@", errorString);
     } else {
       NSLog(@"%@", errorString);
@@ -664,37 +664,37 @@ bitstadium_info_t bitstadium_library_info __attribute__((section("__TEXT,__bit_h
   if (_validAppIdentifier) {
 #if HOCKEYSDK_FEATURE_CRASH_REPORTER
     BITHockeyLog(@"INFO: Setup CrashManager");
-    _crashManager = [[BITCrashManager alloc] initWithAppIdentifier:_appIdentifier isTestFlightEnvironment:_testFlightEnvironment isAppStoreEnvironment:_appStoreEnvironment];
+    _crashManager = [[BITCrashManager alloc] initWithAppIdentifier:_appIdentifier appEnvironment:_appEnvironment];
     _crashManager.hockeyAppClient = [self hockeyAppClient];
     _crashManager.delegate = _delegate;
 #endif /* HOCKEYSDK_FEATURE_CRASH_REPORTER */
     
 #if HOCKEYSDK_FEATURE_UPDATES
     BITHockeyLog(@"INFO: Setup UpdateManager");
-    _updateManager = [[BITUpdateManager alloc] initWithAppIdentifier:_appIdentifier isTestFlightEnvironment:_testFlightEnvironment isAppStoreEnvironment:_appStoreEnvironment];
+    _updateManager = [[BITUpdateManager alloc] initWithAppIdentifier:_appIdentifier appEnvironment:_appEnvironment];
     _updateManager.delegate = _delegate;
 #endif /* HOCKEYSDK_FEATURE_UPDATES */
 
 #if HOCKEYSDK_FEATURE_STORE_UPDATES
     BITHockeyLog(@"INFO: Setup StoreUpdateManager");
-    _storeUpdateManager = [[BITStoreUpdateManager alloc] initWithAppIdentifier:_appIdentifier isTestFlightEnvironment:_testFlightEnvironment isAppStoreEnvironment:_appStoreEnvironment];
+    _storeUpdateManager = [[BITStoreUpdateManager alloc] initWithAppIdentifier:_appIdentifier appEnvironment:_appEnvironment];
     _storeUpdateManager.delegate = _delegate;
 #endif /* HOCKEYSDK_FEATURE_STORE_UPDATES */
     
 #if HOCKEYSDK_FEATURE_FEEDBACK
     BITHockeyLog(@"INFO: Setup FeedbackManager");
-    _feedbackManager = [[BITFeedbackManager alloc] initWithAppIdentifier:_appIdentifier isTestFlightEnvironment:_testFlightEnvironment isAppStoreEnvironment:_appStoreEnvironment];
+    _feedbackManager = [[BITFeedbackManager alloc] initWithAppIdentifier:_appIdentifier appEnvironment:_appEnvironment];
     _feedbackManager.delegate = _delegate;
 #endif /* HOCKEYSDK_FEATURE_FEEDBACK */
 
 #if HOCKEYSDK_FEATURE_AUTHENTICATOR
     BITHockeyLog(@"INFO: Setup Authenticator");
-    _authenticator = [[BITAuthenticator alloc] initWithAppIdentifier:_appIdentifier isTestFlightEnvironment:_testFlightEnvironment isAppStoreEnvironment:_appStoreEnvironment];
+    _authenticator = [[BITAuthenticator alloc] initWithAppIdentifier:_appIdentifier appEnvironment:_appEnvironment];
     _authenticator.hockeyAppClient = [self hockeyAppClient];
     _authenticator.delegate = _delegate;
 #endif /* HOCKEYSDK_FEATURE_AUTHENTICATOR */
 
-    if (![self isAppStoreEnvironment]) {
+    if (self.appEnvironment != BITEnvironmentAppStore) {
       NSString *integrationFlowTime = [self integrationFlowTimeString];
       if (integrationFlowTime && [self integrationFlowStartedWithTimeString:integrationFlowTime]) {
         [self pingServerForIntegrationStartWorkflowWithTimeString:integrationFlowTime appIdentifier:_appIdentifier];

--- a/Classes/BITHockeyManager.m
+++ b/Classes/BITHockeyManager.m
@@ -664,32 +664,32 @@ bitstadium_info_t bitstadium_library_info __attribute__((section("__TEXT,__bit_h
   if (_validAppIdentifier) {
 #if HOCKEYSDK_FEATURE_CRASH_REPORTER
     BITHockeyLog(@"INFO: Setup CrashManager");
-    _crashManager = [[BITCrashManager alloc] initWithAppIdentifier:_appIdentifier isAppStoreEnvironment:_appStoreEnvironment];
+    _crashManager = [[BITCrashManager alloc] initWithAppIdentifier:_appIdentifier isTestFlightEnvironment:_testFlightEnvironment isAppStoreEnvironment:_appStoreEnvironment];
     _crashManager.hockeyAppClient = [self hockeyAppClient];
     _crashManager.delegate = _delegate;
 #endif /* HOCKEYSDK_FEATURE_CRASH_REPORTER */
     
 #if HOCKEYSDK_FEATURE_UPDATES
     BITHockeyLog(@"INFO: Setup UpdateManager");
-    _updateManager = [[BITUpdateManager alloc] initWithAppIdentifier:_appIdentifier isAppStoreEnvironment:_appStoreEnvironment];
+    _updateManager = [[BITUpdateManager alloc] initWithAppIdentifier:_appIdentifier isTestFlightEnvironment:_testFlightEnvironment isAppStoreEnvironment:_appStoreEnvironment];
     _updateManager.delegate = _delegate;
 #endif /* HOCKEYSDK_FEATURE_UPDATES */
 
 #if HOCKEYSDK_FEATURE_STORE_UPDATES
     BITHockeyLog(@"INFO: Setup StoreUpdateManager");
-    _storeUpdateManager = [[BITStoreUpdateManager alloc] initWithAppIdentifier:_appIdentifier isAppStoreEnvironment:_appStoreEnvironment];
+    _storeUpdateManager = [[BITStoreUpdateManager alloc] initWithAppIdentifier:_appIdentifier isTestFlightEnvironment:_testFlightEnvironment isAppStoreEnvironment:_appStoreEnvironment];
     _storeUpdateManager.delegate = _delegate;
 #endif /* HOCKEYSDK_FEATURE_STORE_UPDATES */
     
 #if HOCKEYSDK_FEATURE_FEEDBACK
     BITHockeyLog(@"INFO: Setup FeedbackManager");
-    _feedbackManager = [[BITFeedbackManager alloc] initWithAppIdentifier:_appIdentifier isAppStoreEnvironment:_appStoreEnvironment];
+    _feedbackManager = [[BITFeedbackManager alloc] initWithAppIdentifier:_appIdentifier isTestFlightEnvironment:_testFlightEnvironment isAppStoreEnvironment:_appStoreEnvironment];
     _feedbackManager.delegate = _delegate;
 #endif /* HOCKEYSDK_FEATURE_FEEDBACK */
 
 #if HOCKEYSDK_FEATURE_AUTHENTICATOR
     BITHockeyLog(@"INFO: Setup Authenticator");
-    _authenticator = [[BITAuthenticator alloc] initWithAppIdentifier:_appIdentifier isAppStoreEnvironment:_appStoreEnvironment];
+    _authenticator = [[BITAuthenticator alloc] initWithAppIdentifier:_appIdentifier isTestFlightEnvironment:_testFlightEnvironment isAppStoreEnvironment:_appStoreEnvironment];
     _authenticator.hockeyAppClient = [self hockeyAppClient];
     _authenticator.delegate = _delegate;
 #endif /* HOCKEYSDK_FEATURE_AUTHENTICATOR */

--- a/Classes/BITStoreUpdateManager.m
+++ b/Classes/BITStoreUpdateManager.m
@@ -261,7 +261,7 @@
 #pragma mark - Private
 
 - (BOOL)shouldCancelProcessing {
-  if (![self isAppStoreEnvironment]) return YES;
+  if (self.appEnvironment != BITEnvironmentAppStore) return YES;
   if (![self isStoreUpdateManagerEnabled]) return YES;
   return NO;
 }

--- a/Classes/BITUpdateManager.m
+++ b/Classes/BITUpdateManager.m
@@ -851,9 +851,8 @@ typedef NS_ENUM(NSInteger, BITUpdateAlertViewTag) {
     return;
   }
   
-  NSMutableString *parameter = [NSMutableString stringWithFormat:@"api/2/apps/%@?format=json&extended=true%@&sdk=%@&sdk_version=%@&uuid=%@",
+  NSMutableString *parameter = [NSMutableString stringWithFormat:@"api/2/apps/%@?format=json&extended=true&sdk=%@&sdk_version=%@&uuid=%@",
                                 bit_URLEncodedString([self encodedAppIdentifier]),
-                                ([self isAppStoreEnvironment] ? @"&udid=appstore" : @""),
                                 BITHOCKEY_NAME,
                                 BITHOCKEY_VERSION,
                                 _uuid];

--- a/Classes/BITUpdateManager.m
+++ b/Classes/BITUpdateManager.m
@@ -227,7 +227,7 @@ typedef NS_ENUM(NSInteger, BITUpdateAlertViewTag) {
 #pragma mark - Expiry
 
 - (BOOL)expiryDateReached {
-  if ([self isTestFlightEnvironment] || [self isAppStoreEnvironment]) return NO;
+  if (self.appEnvironment != BITEnvironmentOther) return NO;
   
   if (_expiryDate) {
     NSDate *currentDate = [NSDate date];
@@ -314,7 +314,7 @@ typedef NS_ENUM(NSInteger, BITUpdateAlertViewTag) {
 }
 
 - (void)stopUsage {
-  if ([self isTestFlightEnvironment] || [self isAppStoreEnvironment]) return;
+  if (self.appEnvironment != BITEnvironmentOther) return;
   if ([self expiryDateReached]) return;
   
   double timeDifference = [[NSDate date] timeIntervalSinceReferenceDate] - [_usageStartTimestamp timeIntervalSinceReferenceDate];
@@ -324,7 +324,7 @@ typedef NS_ENUM(NSInteger, BITUpdateAlertViewTag) {
 }
 
 - (void) storeUsageTimeForCurrentVersion:(NSNumber *)usageTime {
-  if ([self isTestFlightEnvironment] || [self isAppStoreEnvironment]) return;
+  if (self.appEnvironment != BITEnvironmentOther) return;
   
   NSMutableData *data = [[NSMutableData alloc] init];
   NSKeyedArchiver *archiver = [[NSKeyedArchiver alloc] initForWritingWithMutableData:data];
@@ -518,7 +518,7 @@ typedef NS_ENUM(NSInteger, BITUpdateAlertViewTag) {
 #pragma mark - BetaUpdateUI
 
 - (BITUpdateViewController *)hockeyViewController:(BOOL)modal {
-  if ([self isTestFlightEnvironment] || [self isAppStoreEnvironment]) {
+  if (self.appEnvironment != BITEnvironmentOther) {
     NSLog(@"[HockeySDK] This should not be called from an app store build!");
     // return an empty view controller instead
     BITHockeyBaseViewController *blankViewController = [[BITHockeyBaseViewController alloc] initWithModalStyle:modal];
@@ -528,7 +528,7 @@ typedef NS_ENUM(NSInteger, BITUpdateAlertViewTag) {
 }
 
 - (void)showUpdateView {
-  if ([self isTestFlightEnvironment] || [self isAppStoreEnvironment]) {
+  if (self.appEnvironment != BITEnvironmentOther) {
     NSLog(@"[HockeySDK] This should not be called from an app store build!");
     return;
   }
@@ -550,7 +550,7 @@ typedef NS_ENUM(NSInteger, BITUpdateAlertViewTag) {
 
 
 - (void)showCheckForUpdateAlert {
-  if ([self isTestFlightEnvironment] || [self isAppStoreEnvironment]) return;
+  if (self.appEnvironment != BITEnvironmentOther) return;
   if ([self isUpdateManagerDisabled]) return;
   
   if (!_updateAlertShowing) {
@@ -825,7 +825,7 @@ typedef NS_ENUM(NSInteger, BITUpdateAlertViewTag) {
 }
 
 - (void)checkForUpdate {
-  if (![self isTestFlightEnvironment] && ![self isAppStoreEnvironment] && ![self isUpdateManagerDisabled]) {
+  if ((self.appEnvironment == BITEnvironmentOther) && ![self isUpdateManagerDisabled]) {
     if ([self expiryDateReached]) return;
     if (![self installationIdentified]) return;
     
@@ -838,7 +838,7 @@ typedef NS_ENUM(NSInteger, BITUpdateAlertViewTag) {
 }
 
 - (void)checkForUpdateShowFeedback:(BOOL)feedback {
-  if ([self isTestFlightEnvironment] || [self isAppStoreEnvironment]) return;
+  if (self.appEnvironment != BITEnvironmentOther) return;
   if (self.isCheckInProgress) return;
   
   _showFeedback = feedback;
@@ -915,7 +915,7 @@ typedef NS_ENUM(NSInteger, BITUpdateAlertViewTag) {
 }
 
 - (BOOL)initiateAppDownload {
-  if ([self isTestFlightEnvironment] || [self isAppStoreEnvironment]) return NO;
+  if (self.appEnvironment != BITEnvironmentOther) return NO;
   
   if (!self.isUpdateAvailable) {
     BITHockeyLog(@"WARNING: No update available. Aborting.");
@@ -984,7 +984,7 @@ typedef NS_ENUM(NSInteger, BITUpdateAlertViewTag) {
 
 // begin the startup process
 - (void)startManager {
-  if (![self isTestFlightEnvironment] && ![self isAppStoreEnvironment]) {
+  if (self.appEnvironment == BITEnvironmentOther) {
     if ([self isUpdateManagerDisabled]) return;
     
     BITHockeyLog(@"INFO: Starting UpdateManager");
@@ -1039,7 +1039,7 @@ typedef NS_ENUM(NSInteger, BITUpdateAlertViewTag) {
       
       self.companyName = (([[json valueForKey:@"company"] isKindOfClass:[NSString class]]) ? [json valueForKey:@"company"] : nil);
       
-      if (![self isTestFlightEnvironment] && ![self isAppStoreEnvironment]) {
+      if (self.appEnvironment == BITEnvironmentOther) {
         NSArray *feedArray = (NSArray *)[json valueForKey:@"versions"];
         
         // remember that we just checked the server

--- a/Classes/BITUpdateManager.m
+++ b/Classes/BITUpdateManager.m
@@ -227,7 +227,7 @@ typedef NS_ENUM(NSInteger, BITUpdateAlertViewTag) {
 #pragma mark - Expiry
 
 - (BOOL)expiryDateReached {
-  if ([self isAppStoreEnvironment]) return NO;
+  if ([self isTestFlightEnvironment] || [self isAppStoreEnvironment]) return NO;
   
   if (_expiryDate) {
     NSDate *currentDate = [NSDate date];
@@ -314,7 +314,7 @@ typedef NS_ENUM(NSInteger, BITUpdateAlertViewTag) {
 }
 
 - (void)stopUsage {
-  if ([self isAppStoreEnvironment]) return;
+  if ([self isTestFlightEnvironment] || [self isAppStoreEnvironment]) return;
   if ([self expiryDateReached]) return;
   
   double timeDifference = [[NSDate date] timeIntervalSinceReferenceDate] - [_usageStartTimestamp timeIntervalSinceReferenceDate];
@@ -324,7 +324,7 @@ typedef NS_ENUM(NSInteger, BITUpdateAlertViewTag) {
 }
 
 - (void) storeUsageTimeForCurrentVersion:(NSNumber *)usageTime {
-  if ([self isAppStoreEnvironment]) return;
+  if ([self isTestFlightEnvironment] || [self isAppStoreEnvironment]) return;
   
   NSMutableData *data = [[NSMutableData alloc] init];
   NSKeyedArchiver *archiver = [[NSKeyedArchiver alloc] initForWritingWithMutableData:data];
@@ -518,7 +518,7 @@ typedef NS_ENUM(NSInteger, BITUpdateAlertViewTag) {
 #pragma mark - BetaUpdateUI
 
 - (BITUpdateViewController *)hockeyViewController:(BOOL)modal {
-  if ([self isAppStoreEnvironment]) {
+  if ([self isTestFlightEnvironment] || [self isAppStoreEnvironment]) {
     NSLog(@"[HockeySDK] This should not be called from an app store build!");
     // return an empty view controller instead
     BITHockeyBaseViewController *blankViewController = [[BITHockeyBaseViewController alloc] initWithModalStyle:modal];
@@ -528,7 +528,7 @@ typedef NS_ENUM(NSInteger, BITUpdateAlertViewTag) {
 }
 
 - (void)showUpdateView {
-  if ([self isAppStoreEnvironment]) {
+  if ([self isTestFlightEnvironment] || [self isAppStoreEnvironment]) {
     NSLog(@"[HockeySDK] This should not be called from an app store build!");
     return;
   }
@@ -550,7 +550,7 @@ typedef NS_ENUM(NSInteger, BITUpdateAlertViewTag) {
 
 
 - (void)showCheckForUpdateAlert {
-  if ([self isAppStoreEnvironment]) return;
+  if ([self isTestFlightEnvironment] || [self isAppStoreEnvironment]) return;
   if ([self isUpdateManagerDisabled]) return;
   
   if (!_updateAlertShowing) {
@@ -825,7 +825,7 @@ typedef NS_ENUM(NSInteger, BITUpdateAlertViewTag) {
 }
 
 - (void)checkForUpdate {
-  if (![self isAppStoreEnvironment] && ![self isUpdateManagerDisabled]) {
+  if (![self isTestFlightEnvironment] && ![self isAppStoreEnvironment] && ![self isUpdateManagerDisabled]) {
     if ([self expiryDateReached]) return;
     if (![self installationIdentified]) return;
     
@@ -838,7 +838,7 @@ typedef NS_ENUM(NSInteger, BITUpdateAlertViewTag) {
 }
 
 - (void)checkForUpdateShowFeedback:(BOOL)feedback {
-  if ([self isAppStoreEnvironment]) return;
+  if ([self isTestFlightEnvironment] || [self isAppStoreEnvironment]) return;
   if (self.isCheckInProgress) return;
   
   _showFeedback = feedback;
@@ -916,7 +916,7 @@ typedef NS_ENUM(NSInteger, BITUpdateAlertViewTag) {
 }
 
 - (BOOL)initiateAppDownload {
-  if ([self isAppStoreEnvironment]) return NO;
+  if ([self isTestFlightEnvironment] || [self isAppStoreEnvironment]) return NO;
   
   if (!self.isUpdateAvailable) {
     BITHockeyLog(@"WARNING: No update available. Aborting.");
@@ -985,7 +985,7 @@ typedef NS_ENUM(NSInteger, BITUpdateAlertViewTag) {
 
 // begin the startup process
 - (void)startManager {
-  if (![self isAppStoreEnvironment]) {
+  if (![self isTestFlightEnvironment] && ![self isAppStoreEnvironment]) {
     if ([self isUpdateManagerDisabled]) return;
     
     BITHockeyLog(@"INFO: Starting UpdateManager");
@@ -1040,7 +1040,7 @@ typedef NS_ENUM(NSInteger, BITUpdateAlertViewTag) {
       
       self.companyName = (([[json valueForKey:@"company"] isKindOfClass:[NSString class]]) ? [json valueForKey:@"company"] : nil);
       
-      if (![self isAppStoreEnvironment]) {
+      if (![self isTestFlightEnvironment] && ![self isAppStoreEnvironment]) {
         NSArray *feedArray = (NSArray *)[json valueForKey:@"versions"];
         
         // remember that we just checked the server

--- a/Classes/BITUpdateViewController.m
+++ b/Classes/BITUpdateViewController.m
@@ -258,8 +258,8 @@
 - (instancetype)initWithStyle:(UITableViewStyle)style {
   if ((self = [super initWithStyle:UITableViewStylePlain])) {
     _updateManager = [BITHockeyManager sharedHockeyManager].updateManager ;
-    _isAppStoreEnvironment = [BITHockeyManager sharedHockeyManager].isAppStoreEnvironment;
-
+    _isAppStoreEnvironment = [BITHockeyManager sharedHockeyManager].appEnvironment == BITEnvironmentAppStore;
+    
     self.title = BITHockeyLocalizedString(@"UpdateScreenTitle");
     
     _cells = [[NSMutableArray alloc] initWithCapacity:5];

--- a/Classes/BITUpdateViewController.m
+++ b/Classes/BITUpdateViewController.m
@@ -59,7 +59,7 @@
   
   NSMutableArray *_cells;
   
-  BOOL _isAppStoreEnvironment;
+  BITEnvironment _appEnvironment;
 }
 
 
@@ -74,7 +74,7 @@
 }
 
 - (void)restoreStoreButtonStateAnimated:(BOOL)animated {
-  if (_isAppStoreEnvironment) {
+  if (_appEnvironment == BITEnvironmentAppStore) {
     [self setAppStoreButtonState:AppStoreButtonStateOffline animated:animated];
   } else if ([_updateManager isUpdateAvailable]) {
     [self setAppStoreButtonState:AppStoreButtonStateUpdate animated:animated];
@@ -258,7 +258,7 @@
 - (instancetype)initWithStyle:(UITableViewStyle)style {
   if ((self = [super initWithStyle:UITableViewStylePlain])) {
     _updateManager = [BITHockeyManager sharedHockeyManager].updateManager ;
-    _isAppStoreEnvironment = [BITHockeyManager sharedHockeyManager].appEnvironment == BITEnvironmentAppStore;
+    _appEnvironment = [BITHockeyManager sharedHockeyManager].appEnvironment;
     
     self.title = BITHockeyLocalizedString(@"UpdateScreenTitle");
     
@@ -351,7 +351,7 @@
 }
 
 - (void)viewWillAppear:(BOOL)animated {
-  if (_isAppStoreEnvironment) {
+  if (_appEnvironment != BITEnvironmentOther) {
     self.appStoreButtonState = AppStoreButtonStateOffline;
   } else if (self.mandatoryUpdate) {
     self.navigationItem.leftBarButtonItem = nil;

--- a/Classes/HockeySDK.h
+++ b/Classes/HockeySDK.h
@@ -36,6 +36,7 @@
 
 
 #import "HockeySDKFeatureConfig.h"
+#import "HockeySDKEnums.h"
 
 #import "BITHockeyManager.h"
 #import "BITHockeyManagerDelegate.h"
@@ -82,137 +83,9 @@
 // By default the SDK retries sending pending data only when the app becomes active.
 #define BITHockeyNetworkDidBecomeReachableNotification @"BITHockeyNetworkDidBecomeReachable"
 
-
-/**
- *  HockeySDK Crash Reporter error domain
- */
-typedef NS_ENUM (NSInteger, BITCrashErrorReason) {
-  /**
-   *  Unknown error
-   */
-  BITCrashErrorUnknown,
-  /**
-   *  API Server rejected app version
-   */
-  BITCrashAPIAppVersionRejected,
-  /**
-   *  API Server returned empty response
-   */
-  BITCrashAPIReceivedEmptyResponse,
-  /**
-   *  Connection error with status code
-   */
-  BITCrashAPIErrorWithStatusCode
-};
 extern NSString *const __attribute__((unused)) kBITCrashErrorDomain;
-
-/**
- *  HockeySDK Update error domain
- */
-typedef NS_ENUM (NSInteger, BITUpdateErrorReason) {
-  /**
-   *  Unknown error
-   */
-  BITUpdateErrorUnknown,
-  /**
-   *  API Server returned invalid status
-   */
-  BITUpdateAPIServerReturnedInvalidStatus,
-  /**
-   *  API Server returned invalid data
-   */
-  BITUpdateAPIServerReturnedInvalidData,
-  /**
-   *  API Server returned empty response
-   */
-  BITUpdateAPIServerReturnedEmptyResponse,
-  /**
-   *  Authorization secret missing
-   */
-  BITUpdateAPIClientAuthorizationMissingSecret,
-  /**
-   *  No internet connection
-   */
-  BITUpdateAPIClientCannotCreateConnection
-};
 extern NSString *const __attribute__((unused)) kBITUpdateErrorDomain;
-
-
-/**
- *  HockeySDK Feedback error domain
- */
-typedef NS_ENUM(NSInteger, BITFeedbackErrorReason) {
-  /**
-   *  Unknown error
-   */
-  BITFeedbackErrorUnknown,
-  /**
-   *  API Server returned invalid status
-   */
-  BITFeedbackAPIServerReturnedInvalidStatus,
-  /**
-   *  API Server returned invalid data
-   */
-  BITFeedbackAPIServerReturnedInvalidData,
-  /**
-   *  API Server returned empty response
-   */
-  BITFeedbackAPIServerReturnedEmptyResponse,
-  /**
-   *  Authorization secret missing
-   */
-  BITFeedbackAPIClientAuthorizationMissingSecret,
-  /**
-   *  No internet connection
-   */
-  BITFeedbackAPIClientCannotCreateConnection
-};
 extern NSString *const __attribute__((unused)) kBITFeedbackErrorDomain;
-
-/**
- *  HockeySDK Authenticator error domain
- */
-typedef NS_ENUM(NSInteger, BITAuthenticatorReason) {
-  /**
-   *  Unknown error
-   */
-  BITAuthenticatorErrorUnknown,
-  /**
-   *  Network error
-   */
-  BITAuthenticatorNetworkError,
-  
-  /**
-   *  API Server returned invalid response
-   */
-  BITAuthenticatorAPIServerReturnedInvalidResponse,
-  /**
-   *  Not Authorized
-   */
-  BITAuthenticatorNotAuthorized,
-  /**
-   *  Unknown Application ID (configuration error)
-   */
-  BITAuthenticatorUnknownApplicationID,
-  /**
-   *  Authorization secret missing
-   */
-  BITAuthenticatorAuthorizationSecretMissing,
-  /**
-   *  Not yet identified
-   */
-  BITAuthenticatorNotIdentified,
-};
 extern NSString *const __attribute__((unused)) kBITAuthenticatorErrorDomain;
-
-/**
- *  HockeySDK global error domain
- */
-typedef NS_ENUM(NSInteger, BITHockeyErrorReason) {
-  /**
-   *  Unknown error
-   */
-  BITHockeyErrorUnknown
-};
 extern NSString *const __attribute__((unused)) kBITHockeyErrorDomain;
 

--- a/Classes/HockeySDKEnums.h
+++ b/Classes/HockeySDKEnums.h
@@ -1,0 +1,157 @@
+//
+//  HockeySDKEnums.h
+//  HockeySDK
+//
+//  Created by Lukas Spieß on 08/10/15.
+//
+//
+
+#ifndef HockeySDK_HockeyEnums_h
+#define HockeySDK_HockeyEnums_h
+
+/**
+ *  HockeySDK App environment
+ */
+typedef NS_ENUM(NSInteger, BITEnvironment) {
+  /**
+   *  App has been downloaded from the AppStore
+   */
+  BITEnvironmentAppStore = 0,
+  /**
+   *  App has been downloaded from TestFlight
+   */
+  BITEnvironmentTestFlight = 1,
+  /**
+   *  App has been installed by some other mechanism
+   */
+  BITEnvironmentOther = 99
+};
+
+/**
+ *  HockeySDK Crash Reporter error domain
+ */
+typedef NS_ENUM (NSInteger, BITCrashErrorReason) {
+  /**
+   *  Unknown error
+   */
+  BITCrashErrorUnknown,
+  /**
+   *  API Server rejected app version
+   */
+  BITCrashAPIAppVersionRejected,
+  /**
+   *  API Server returned empty response
+   */
+  BITCrashAPIReceivedEmptyResponse,
+  /**
+   *  Connection error with status code
+   */
+  BITCrashAPIErrorWithStatusCode
+};
+
+/**
+ *  HockeySDK Update error domain
+ */
+typedef NS_ENUM (NSInteger, BITUpdateErrorReason) {
+  /**
+   *  Unknown error
+   */
+  BITUpdateErrorUnknown,
+  /**
+   *  API Server returned invalid status
+   */
+  BITUpdateAPIServerReturnedInvalidStatus,
+  /**
+   *  API Server returned invalid data
+   */
+  BITUpdateAPIServerReturnedInvalidData,
+  /**
+   *  API Server returned empty response
+   */
+  BITUpdateAPIServerReturnedEmptyResponse,
+  /**
+   *  Authorization secret missing
+   */
+  BITUpdateAPIClientAuthorizationMissingSecret,
+  /**
+   *  No internet connection
+   */
+  BITUpdateAPIClientCannotCreateConnection
+};
+
+/**
+ *  HockeySDK Feedback error domain
+ */
+typedef NS_ENUM(NSInteger, BITFeedbackErrorReason) {
+  /**
+   *  Unknown error
+   */
+  BITFeedbackErrorUnknown,
+  /**
+   *  API Server returned invalid status
+   */
+  BITFeedbackAPIServerReturnedInvalidStatus,
+  /**
+   *  API Server returned invalid data
+   */
+  BITFeedbackAPIServerReturnedInvalidData,
+  /**
+   *  API Server returned empty response
+   */
+  BITFeedbackAPIServerReturnedEmptyResponse,
+  /**
+   *  Authorization secret missing
+   */
+  BITFeedbackAPIClientAuthorizationMissingSecret,
+  /**
+   *  No internet connection
+   */
+  BITFeedbackAPIClientCannotCreateConnection
+};
+
+/**
+ *  HockeySDK Authenticator error domain
+ */
+typedef NS_ENUM(NSInteger, BITAuthenticatorReason) {
+  /**
+   *  Unknown error
+   */
+  BITAuthenticatorErrorUnknown,
+  /**
+   *  Network error
+   */
+  BITAuthenticatorNetworkError,
+  
+  /**
+   *  API Server returned invalid response
+   */
+  BITAuthenticatorAPIServerReturnedInvalidResponse,
+  /**
+   *  Not Authorized
+   */
+  BITAuthenticatorNotAuthorized,
+  /**
+   *  Unknown Application ID (configuration error)
+   */
+  BITAuthenticatorUnknownApplicationID,
+  /**
+   *  Authorization secret missing
+   */
+  BITAuthenticatorAuthorizationSecretMissing,
+  /**
+   *  Not yet identified
+   */
+  BITAuthenticatorNotIdentified,
+};
+
+/**
+ *  HockeySDK global error domain
+ */
+typedef NS_ENUM(NSInteger, BITHockeyErrorReason) {
+  /**
+   *  Unknown error
+   */
+  BITHockeyErrorUnknown
+};
+
+#endif /* HockeySDK_HockeyEnums_h */

--- a/Classes/HockeySDKEnums.h
+++ b/Classes/HockeySDKEnums.h
@@ -22,7 +22,8 @@ typedef NS_ENUM(NSInteger, BITEnvironment) {
    */
   BITEnvironmentTestFlight = 1,
   /**
-   *  App has been installed by some other mechanism
+   *  App has been installed by some other mechanism.
+   *  This could be Ad-Hoc, Enterprise, etc.
    */
   BITEnvironmentOther = 99
 };

--- a/Classes/HockeySDKPrivate.h
+++ b/Classes/HockeySDKPrivate.h
@@ -67,7 +67,7 @@
 #define BITHOCKEYSDK_BUNDLE @"HockeySDKResources.bundle"
 #define BITHOCKEYSDK_URL @"https://sdk.hockeyapp.net/"
 
-#define BITHockeyLog(fmt, ...) do { if([BITHockeyManager sharedHockeyManager].isDebugLogEnabled && ![BITHockeyManager sharedHockeyManager].isAppStoreEnvironment) { NSLog((@"[HockeySDK] %s/%d " fmt), __PRETTY_FUNCTION__, __LINE__, ##__VA_ARGS__); }} while(0)
+#define BITHockeyLog(fmt, ...) do { if([BITHockeyManager sharedHockeyManager].isDebugLogEnabled && ([BITHockeyManager sharedHockeyManager].appEnvironment != BITEnvironmentAppStore)) { NSLog((@"[HockeySDK] %s/%d " fmt), __PRETTY_FUNCTION__, __LINE__, ##__VA_ARGS__); }} while(0)
 
 #define BIT_RGBCOLOR(r,g,b) [UIColor colorWithRed:(r)/255.0 green:(g)/255.0 blue:(b)/255.0 alpha:1]
 

--- a/Support/HockeySDK.xcodeproj/project.pbxproj
+++ b/Support/HockeySDK.xcodeproj/project.pbxproj
@@ -278,6 +278,8 @@
 		1EF95CA7162CB037000AE3AD /* BITFeedbackActivity.m in Sources */ = {isa = PBXBuildFile; fileRef = 1EF95CA5162CB036000AE3AD /* BITFeedbackActivity.m */; };
 		1EF95CAA162CB314000AE3AD /* BITFeedbackComposeViewControllerDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1EF95CA9162CB313000AE3AD /* BITFeedbackComposeViewControllerDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1EFF03E517F2485500A5F13C /* BITCrashManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1EFF03E417F2485500A5F13C /* BITCrashManagerTests.m */; };
+		807756401BC6A44E0037C3DA /* HockeySDKEnums.h in Headers */ = {isa = PBXBuildFile; fileRef = 8077563F1BC6A44D0037C3DA /* HockeySDKEnums.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		807756411BC6B6050037C3DA /* HockeySDKEnums.h in Headers */ = {isa = PBXBuildFile; fileRef = 8077563F1BC6A44D0037C3DA /* HockeySDKEnums.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		846A901F1B20B0EB0076BB80 /* BITCrashCXXExceptionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 846A901D1B20B0EB0076BB80 /* BITCrashCXXExceptionHandler.h */; };
 		846A90201B20B0EB0076BB80 /* BITCrashCXXExceptionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 846A901D1B20B0EB0076BB80 /* BITCrashCXXExceptionHandler.h */; };
 		846A90211B20B0EB0076BB80 /* BITCrashCXXExceptionHandler.mm in Sources */ = {isa = PBXBuildFile; fileRef = 846A901E1B20B0EB0076BB80 /* BITCrashCXXExceptionHandler.mm */; };
@@ -526,6 +528,7 @@
 		1EF95CA9162CB313000AE3AD /* BITFeedbackComposeViewControllerDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BITFeedbackComposeViewControllerDelegate.h; sourceTree = "<group>"; };
 		1EFF03D717F20F8300A5F13C /* BITCrashManagerPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BITCrashManagerPrivate.h; sourceTree = "<group>"; };
 		1EFF03E417F2485500A5F13C /* BITCrashManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BITCrashManagerTests.m; sourceTree = "<group>"; };
+		8077563F1BC6A44D0037C3DA /* HockeySDKEnums.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HockeySDKEnums.h; sourceTree = "<group>"; };
 		846A901D1B20B0EB0076BB80 /* BITCrashCXXExceptionHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BITCrashCXXExceptionHandler.h; sourceTree = "<group>"; };
 		846A901E1B20B0EB0076BB80 /* BITCrashCXXExceptionHandler.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = BITCrashCXXExceptionHandler.mm; sourceTree = "<group>"; };
 		973EC8B518BCA8A200DBFFBB /* BITRectangleImageAnnotation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BITRectangleImageAnnotation.h; sourceTree = "<group>"; };
@@ -755,8 +758,12 @@
 		1E754E441621F95E0070AB92 /* Helper */ = {
 			isa = PBXGroup;
 			children = (
-				1E49A4D4161222D400463151 /* HockeySDKPrivate.h */,
-				1E49A4D5161222D400463151 /* HockeySDKPrivate.m */,
+				1E49A4A7161222B900463151 /* BITAppStoreHeader.h */,
+				1E49A4A8161222B900463151 /* BITAppStoreHeader.m */,
+				1EACC979162F041E007578C5 /* BITAttributedLabel.h */,
+				1EACC97A162F041E007578C5 /* BITAttributedLabel.m */,
+				1EB92E711955C38C0093C8B6 /* BITHockeyAttachment.h */,
+				1EB92E721955C38C0093C8B6 /* BITHockeyAttachment.m */,
 				1E49A4A0161222B900463151 /* BITHockeyBaseManager.h */,
 				1E49A4A1161222B900463151 /* BITHockeyBaseManager.m */,
 				1E49A4A2161222B900463151 /* BITHockeyBaseManagerPrivate.h */,
@@ -766,17 +773,14 @@
 				1E49A4A6161222B900463151 /* BITHockeyHelper.m */,
 				1E0FEE26173BDB260061331F /* BITKeychainUtils.h */,
 				1E0FEE27173BDB260061331F /* BITKeychainUtils.m */,
-				1EACC979162F041E007578C5 /* BITAttributedLabel.h */,
-				1EACC97A162F041E007578C5 /* BITAttributedLabel.m */,
-				1E49A4A7161222B900463151 /* BITAppStoreHeader.h */,
-				1E49A4A8161222B900463151 /* BITAppStoreHeader.m */,
 				1E49A4A9161222B900463151 /* BITStoreButton.h */,
 				1E49A4AA161222B900463151 /* BITStoreButton.m */,
 				1E49A4AB161222B900463151 /* BITWebTableViewCell.h */,
 				1E49A4AC161222B900463151 /* BITWebTableViewCell.m */,
-				1EB92E711955C38C0093C8B6 /* BITHockeyAttachment.h */,
-				1EB92E721955C38C0093C8B6 /* BITHockeyAttachment.m */,
+				8077563F1BC6A44D0037C3DA /* HockeySDKEnums.h */,
 				1E3A260E1B2B207900D59683 /* HockeySDKNullability.h */,
+				1E49A4D4161222D400463151 /* HockeySDKPrivate.h */,
+				1E49A4D5161222D400463151 /* HockeySDKPrivate.m */,
 			);
 			name = Helper;
 			sourceTree = "<group>";
@@ -1098,6 +1102,7 @@
 				973EC8BB18BDE29800DBFFBB /* BITArrowImageAnnotation.h in Headers */,
 				1E49A4C4161222B900463151 /* BITAppStoreHeader.h in Headers */,
 				1E49A4CA161222B900463151 /* BITStoreButton.h in Headers */,
+				807756401BC6A44E0037C3DA /* HockeySDKEnums.h in Headers */,
 				973EC8B718BCA8A200DBFFBB /* BITRectangleImageAnnotation.h in Headers */,
 				1E49A4D0161222B900463151 /* BITWebTableViewCell.h in Headers */,
 				1EB6181F1B0A5FA70035A986 /* BITAuthenticator_Private.h in Headers */,
@@ -1148,6 +1153,7 @@
 				1EB617A41B0A31940035A986 /* BITUpdateManager.h in Headers */,
 				1EB617AC1B0A31BA0035A986 /* BITHockeyManager.h in Headers */,
 				1EB617A71B0A31A30035A986 /* BITUpdateViewController.h in Headers */,
+				807756411BC6B6050037C3DA /* HockeySDKEnums.h in Headers */,
 				1EB617631B0A30AE0035A986 /* BITHockeyHelper.h in Headers */,
 				1EB617A51B0A319A0035A986 /* BITUpdateManagerDelegate.h in Headers */,
 				1EB617CF1B0A344A0035A986 /* BITHockeyAppClient.h in Headers */,

--- a/Support/HockeySDKTests/BITAuthenticatorTests.m
+++ b/Support/HockeySDKTests/BITAuthenticatorTests.m
@@ -58,7 +58,7 @@ static void *kInstallationIdentification = &kInstallationIdentification;
 - (void)setUp {
   [super setUp];
   
-  _sut = [[BITAuthenticator alloc] initWithAppIdentifier:nil isAppStoreEnvironment:NO];
+  _sut = [[BITAuthenticator alloc] initWithAppIdentifier:nil isTestFlightEnvironment:NO isAppStoreEnvironment:NO];
 }
 
 - (void)tearDown {
@@ -87,7 +87,7 @@ static void *kInstallationIdentification = &kInstallationIdentification;
 #pragma mark - Persistence Tests
 - (void) testThatLastAuthenticatedVersionIsPersisted {
   _sut.lastAuthenticatedVersion = @"1.2.1";
-  _sut = [[BITAuthenticator alloc] initWithAppIdentifier:nil isAppStoreEnvironment:YES];
+  _sut = [[BITAuthenticator alloc] initWithAppIdentifier:nil isTestFlightEnvironment:NO isAppStoreEnvironment:YES];
   assertThat(_sut.lastAuthenticatedVersion, equalTo(@"1.2.1"));
 }
 

--- a/Support/HockeySDKTests/BITAuthenticatorTests.m
+++ b/Support/HockeySDKTests/BITAuthenticatorTests.m
@@ -58,7 +58,7 @@ static void *kInstallationIdentification = &kInstallationIdentification;
 - (void)setUp {
   [super setUp];
   
-  _sut = [[BITAuthenticator alloc] initWithAppIdentifier:nil isTestFlightEnvironment:NO isAppStoreEnvironment:NO];
+  _sut = [[BITAuthenticator alloc] initWithAppIdentifier:nil appEnvironment:BITEnvironmentOther];
 }
 
 - (void)tearDown {
@@ -87,7 +87,7 @@ static void *kInstallationIdentification = &kInstallationIdentification;
 #pragma mark - Persistence Tests
 - (void) testThatLastAuthenticatedVersionIsPersisted {
   _sut.lastAuthenticatedVersion = @"1.2.1";
-  _sut = [[BITAuthenticator alloc] initWithAppIdentifier:nil isTestFlightEnvironment:NO isAppStoreEnvironment:YES];
+  _sut = [[BITAuthenticator alloc] initWithAppIdentifier:nil appEnvironment:BITEnvironmentAppStore];
   assertThat(_sut.lastAuthenticatedVersion, equalTo(@"1.2.1"));
 }
 

--- a/Support/HockeySDKTests/BITCrashManagerTests.m
+++ b/Support/HockeySDKTests/BITCrashManagerTests.m
@@ -41,7 +41,7 @@
   [super setUp];
   
   _startManagerInitialized = NO;
-  _sut = [[BITCrashManager alloc] initWithAppIdentifier:nil isAppStoreEnvironment:NO];
+  _sut = [[BITCrashManager alloc] initWithAppIdentifier:nil isTestFlightEnvironment:NO isAppStoreEnvironment:NO];
 
   _hockeyAppClient = [[BITHockeyAppClient alloc] initWithBaseURL:[NSURL URLWithString: BITHOCKEYSDK_URL]];
   _hockeyAppClient.baseURL = [NSURL URLWithString:BITHOCKEYSDK_URL];

--- a/Support/HockeySDKTests/BITCrashManagerTests.m
+++ b/Support/HockeySDKTests/BITCrashManagerTests.m
@@ -41,7 +41,7 @@
   [super setUp];
   
   _startManagerInitialized = NO;
-  _sut = [[BITCrashManager alloc] initWithAppIdentifier:nil isTestFlightEnvironment:NO isAppStoreEnvironment:NO];
+  _sut = [[BITCrashManager alloc] initWithAppIdentifier:nil appEnvironment:BITEnvironmentOther];
 
   _hockeyAppClient = [[BITHockeyAppClient alloc] initWithBaseURL:[NSURL URLWithString: BITHOCKEYSDK_URL]];
   _hockeyAppClient.baseURL = [NSURL URLWithString:BITHOCKEYSDK_URL];

--- a/Support/HockeySDKTests/BITFeedbackManagerTests.m
+++ b/Support/HockeySDKTests/BITFeedbackManagerTests.m
@@ -36,7 +36,7 @@
 
   BITHockeyManager *hm = [BITHockeyManager sharedHockeyManager];
   hm.delegate = nil;
-  _sut = [[BITFeedbackManager alloc] initWithAppIdentifier:nil isAppStoreEnvironment:NO];
+  _sut = [[BITFeedbackManager alloc] initWithAppIdentifier:nil isTestFlightEnvironment:NO isAppStoreEnvironment:NO];
   _sut.delegate = nil;
 }
 

--- a/Support/HockeySDKTests/BITFeedbackManagerTests.m
+++ b/Support/HockeySDKTests/BITFeedbackManagerTests.m
@@ -36,7 +36,7 @@
 
   BITHockeyManager *hm = [BITHockeyManager sharedHockeyManager];
   hm.delegate = nil;
-  _sut = [[BITFeedbackManager alloc] initWithAppIdentifier:nil isTestFlightEnvironment:NO isAppStoreEnvironment:NO];
+  _sut = [[BITFeedbackManager alloc] initWithAppIdentifier:nil appEnvironment:BITEnvironmentOther];
   _sut.delegate = nil;
 }
 

--- a/Support/HockeySDKTests/BITStoreUpdateManagerTests.m
+++ b/Support/HockeySDKTests/BITStoreUpdateManagerTests.m
@@ -38,7 +38,7 @@
   [super setUp];
   
   // Set-up code here.
-  _storeUpdateManager = [[BITStoreUpdateManager alloc] initWithAppIdentifier:nil isTestFlightEnvironment:NO isAppStoreEnvironment:YES];
+  _storeUpdateManager = [[BITStoreUpdateManager alloc] initWithAppIdentifier:nil appEnvironment:BITEnvironmentAppStore];
 }
 
 - (void)tearDown {

--- a/Support/HockeySDKTests/BITStoreUpdateManagerTests.m
+++ b/Support/HockeySDKTests/BITStoreUpdateManagerTests.m
@@ -16,7 +16,7 @@
 #define MOCKITO_SHORTHAND
 #import <OCMockitoIOS/OCMockitoIOS.h>
 
-#import "HockeySDKFeatureConfig.h"
+#import "HockeySDK.h"
 #import "BITStoreUpdateManager.h"
 #import "BITStoreUpdateManagerPrivate.h"
 #import "BITHockeyBaseManager.h"

--- a/Support/HockeySDKTests/BITStoreUpdateManagerTests.m
+++ b/Support/HockeySDKTests/BITStoreUpdateManagerTests.m
@@ -38,7 +38,7 @@
   [super setUp];
   
   // Set-up code here.
-  _storeUpdateManager = [[BITStoreUpdateManager alloc] initWithAppIdentifier:nil isAppStoreEnvironment:YES];
+  _storeUpdateManager = [[BITStoreUpdateManager alloc] initWithAppIdentifier:nil isTestFlightEnvironment:NO isAppStoreEnvironment:YES];
 }
 
 - (void)tearDown {


### PR DESCRIPTION
Since Apple's changes to the way they sign TestFlight builds broke our detection, we decided to move to a more fine grained approach in detecting environments an app can run in.

In favor of this, we deprecate the old `isAppStoreEnvironment` and replace it with a new `appEnvironment` property.
