### PR TITLE
TARGET_IPHONE_SIMULATOR has been deprecated

### DIFF
--- a/Classes/BITCrashReportTextFormatter.m
+++ b/Classes/BITCrashReportTextFormatter.m
@@ -348,7 +348,7 @@ static const char *findSEL (const char *imageName, NSString *imageUUID, uint64_t
         processPath = report.processInfo.processPath;
         
         /* Remove username from the path */
-#if TARGET_IPHONE_SIMULATOR
+#if TARGET_OS_SIMULATOR
         if ([processPath length] > 0)
           processPath = [processPath stringByAbbreviatingWithTildeInPath];
         if ([processPath length] > 0 && [[processPath substringToIndex:1] isEqualToString:@"~"])
@@ -438,7 +438,7 @@ static const char *findSEL (const char *imageName, NSString *imageUUID, uint64_t
     NSString *foundSelector = nil;
 
     // search the registers value for the current arch
-#if TARGET_IPHONE_SIMULATOR
+#if TARGET_OS_SIMULATOR
     if (lp64) {
       foundSelector = [[self class] selectorForRegisterWithName:@"rsi" ofThread:crashed_thread report:report];
       if (foundSelector == NULL)
@@ -577,13 +577,13 @@ static const char *findSEL (const char *imageName, NSString *imageUUID, uint64_t
     /* Remove username from the image path */
     NSString *imageName = @"";
     if (imageInfo.imageName && [imageInfo.imageName length] > 0) {
-#if TARGET_IPHONE_SIMULATOR
+#if TARGET_OS_SIMULATOR
       imageName = [imageInfo.imageName stringByAbbreviatingWithTildeInPath];
 #else
       imageName = imageInfo.imageName;
 #endif
     }
-#if TARGET_IPHONE_SIMULATOR
+#if TARGET_OS_SIMULATOR
     if ([imageName length] > 0 && [[imageName substringToIndex:1] isEqualToString:@"~"])
       imageName = [NSString stringWithFormat:@"/Users/USER%@", [imageName substringFromIndex:1]];
 #endif

--- a/Classes/BITHockeyHelper.m
+++ b/Classes/BITHockeyHelper.m
@@ -272,7 +272,7 @@ BOOL bit_isPreiOS8Environment(void) {
 }
 
 BOOL bit_isAppStoreReceiptSandbox(void) {
-#if TARGET_IPHONE_SIMULATOR
+#if TARGET_OS_SIMULATOR
   return NO;
 #else
   NSURL *appStoreReceiptURL = NSBundle.mainBundle.appStoreReceiptURL;
@@ -289,7 +289,7 @@ BOOL bit_hasEmbeddedMobileProvision(void) {
 }
 
 BOOL bit_isRunningInTestFlightEnvironment(void) {
-#if TARGET_IPHONE_SIMULATOR
+#if TARGET_OS_SIMULATOR
   return NO;
 #else
   if (bit_isAppStoreReceiptSandbox() && !bit_hasEmbeddedMobileProvision()) {
@@ -300,7 +300,7 @@ BOOL bit_isRunningInTestFlightEnvironment(void) {
 }
 
 BOOL bit_isRunningInAppStoreEnvironment(void) {
-#if TARGET_IPHONE_SIMULATOR
+#if TARGET_OS_SIMULATOR
   return NO;
 #else
   if (bit_isAppStoreReceiptSandbox() || bit_hasEmbeddedMobileProvision()) {

--- a/Classes/BITHockeyManager.m
+++ b/Classes/BITHockeyManager.m
@@ -164,7 +164,7 @@ bitstadium_info_t bitstadium_library_info __attribute__((section("__TEXT,__bit_h
     _installString = bit_appAnonID(NO);
     _disableInstallTracking = NO;
     
-#if !TARGET_IPHONE_SIMULATOR
+#if !TARGET_OS_SIMULATOR
     // check if we are really in an app store environment
     if (bit_isRunningInAppStoreEnvironment()) {
       _appEnvironment = BITEnvironmentAppStore;

--- a/Classes/BITUpdateManager.m
+++ b/Classes/BITUpdateManager.m
@@ -924,7 +924,7 @@ typedef NS_ENUM(NSInteger, BITUpdateAlertViewTag) {
     return NO;
   }
   
-#if TARGET_IPHONE_SIMULATOR
+#if TARGET_OS_SIMULATOR
   /* We won't use this for now until we have a more robust solution for displaying UIAlertController
   // requires iOS 8
   id uialertcontrollerClass = NSClassFromString(@"UIAlertController");
@@ -980,7 +980,7 @@ typedef NS_ENUM(NSInteger, BITUpdateAlertViewTag) {
   
   return success;
 
-#endif /* TARGET_IPHONE_SIMULATOR */
+#endif /* TARGET_OS_SIMULATOR */
 }
 
 


### PR DESCRIPTION
Update to use new build flag for detecting simulator. May need to include `TargetConditionals.h` if used in Swift code, which is not the case here.