### PR TITLE
Enable defining custom HTTP headers when uploading crash reports

### DIFF
--- a/Classes/BITCrashManager.m
+++ b/Classes/BITCrashManager.m
@@ -1584,6 +1584,14 @@ static void uncaught_cxx_exception_handler(const BITCrashUncaughtCXXExceptionInf
   [request setCachePolicy: NSURLRequestReloadIgnoringLocalCacheData];
   [request setValue:@"HockeySDK/iOS" forHTTPHeaderField:@"User-Agent"];
   [request setValue:@"gzip" forHTTPHeaderField:@"Accept-Encoding"];
+
+  NSDictionary *headerDictionary = nil;
+  if ([self.delegate respondsToSelector:@selector(crashManagerRequestCustomHeaderDictionary)] &&
+      [(headerDictionary = [self.delegate crashManagerRequestCustomHeaderDictionary]) isKindOfClass:[NSDictionary class]]) {
+    [headerDictionary enumerateKeysAndObjectsUsingBlock:^(NSString* headerField, NSString* value, BOOL * _Nonnull stop) {
+      [request setValue:value forHTTPHeaderField:headerField];
+    }];
+  }
   
   NSString *contentType = [NSString stringWithFormat:@"multipart/form-data; boundary=%@", boundary];
   [request setValue:contentType forHTTPHeaderField:@"Content-type"];

--- a/Classes/BITCrashManager.m
+++ b/Classes/BITCrashManager.m
@@ -1576,7 +1576,11 @@ static void uncaught_cxx_exception_handler(const BITCrashUncaughtCXXExceptionInf
 
 - (NSMutableURLRequest *)requestWithBoundary:(NSString *)boundary {
   NSString *postCrashPath = [NSString stringWithFormat:@"api/2/apps/%@/crashes", self.encodedAppIdentifier];
-  
+  if ([self.delegate respondsToSelector:@selector(crashManagerCustomCrashPath)] &&
+    [[self.delegate crashManagerCustomCrashPath] isKindOfClass:[NSString class]]) {
+    postCrashPath = [self.delegate crashManagerCustomCrashPath];
+  }
+
   NSMutableURLRequest *request = [self.hockeyAppClient requestWithMethod:@"POST"
                                                                     path:postCrashPath
                                                               parameters:nil];

--- a/Classes/BITCrashManagerDelegate.h
+++ b/Classes/BITCrashManagerDelegate.h
@@ -191,4 +191,11 @@
  */
 -(NSDictionary*)crashManagerRequestCustomHeaderDictionary;
 
+/** Define the path of the crash report endpoint
+
+ @return A string that will be appended after the server URL when posting the crash report
+ @see `[BITHockeyManager serverURL]`
+ */
+-(NSString*)crashManagerCustomCrashPath;
+
 @end

--- a/Classes/BITCrashManagerDelegate.h
+++ b/Classes/BITCrashManagerDelegate.h
@@ -180,4 +180,15 @@
  */
 -(BOOL)considerAppNotTerminatedCleanlyReportForCrashManager:(BITCrashManager *)crashManager;
 
+
+/** Define a dictionary of custom NSURLRequest header fields and values
+
+ Define a dictionary of custom NSURLRequest header fields and values that are amended
+ to the request sent to the server.
+
+ @return A dictionary containing header fields and values
+ @see `[BITHockeyManager serverURL]`
+ */
+-(NSDictionary*)crashManagerRequestCustomHeaderDictionary;
+
 @end


### PR DESCRIPTION
This will be useful for defining a custom serverURL (which could be zero-rated) which re-plays the crash report to HockeyApp - while requiring Authorization headers to prevent abuse.
