### PR TITLE
Add additional fallbacks for newer nullability annotation syntax

### DIFF
--- a/Classes/HockeySDKNullability.h
+++ b/Classes/HockeySDKNullability.h
@@ -17,6 +17,8 @@
 #define nonnull
 #define null_unspecified
 #define null_resettable
+#define _Nullable
+#define _Nonnull
 #define __nullable
 #define __nonnull
 #define __null_unspecified


### PR DESCRIPTION
There was some newer syntax added in Xcode 7 for which we don't have a fallback yet
