### PR TITLE
Fix NSURLSession memory leak in Swift apps

### DIFF
--- a/Classes/BITAuthenticator.m
+++ b/Classes/BITAuthenticator.m
@@ -349,11 +349,14 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
   if (isSessionSupported) {
     NSURLRequest *request = [self.hockeyAppClient requestWithMethod:@"GET" path:validationPath parameters:[self validationParameters]];
     NSURLSessionConfiguration *sessionConfiguration = [NSURLSessionConfiguration defaultSessionConfiguration];
-    NSURLSession *session = [NSURLSession sessionWithConfiguration:sessionConfiguration];
+    __block NSURLSession *session = [NSURLSession sessionWithConfiguration:sessionConfiguration];
     
     NSURLSessionDataTask *task = [session dataTaskWithRequest:request
                                             completionHandler: ^(NSData *data, NSURLResponse *response, NSError *error) {
                                               typeof (self) strongSelf = weakSelf;
+                                              
+                                              [session finishTasksAndInvalidate];
+                                              
                                               [strongSelf handleValidationResponseWithData:data error:error completion:completion];
                                             }];
     [task resume];
@@ -478,12 +481,15 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
   __weak typeof (self) weakSelf = self;
   if(isURLSessionSupported) {
     NSURLSessionConfiguration *sessionConfiguration = [NSURLSessionConfiguration defaultSessionConfiguration];
-    NSURLSession *session = [NSURLSession sessionWithConfiguration:sessionConfiguration];
+    __block NSURLSession *session = [NSURLSession sessionWithConfiguration:sessionConfiguration];
     
     NSURLSessionDataTask *task = [session dataTaskWithRequest:request
                                             completionHandler: ^(NSData *data, NSURLResponse *response, NSError *error) {
                                               typeof (self) strongSelf = weakSelf;
                                               NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*) response;
+                                              
+                                              [session finishTasksAndInvalidate];
+                                              
                                               [strongSelf handleAuthenticationWithResponse:httpResponse email:email data:data completion:completion];
                                             }];
     [task resume];

--- a/Classes/BITCrashManager.m
+++ b/Classes/BITCrashManager.m
@@ -1664,7 +1664,7 @@ static void uncaught_cxx_exception_handler(const BITCrashUncaughtCXXExceptionInf
   id nsurlsessionClass = NSClassFromString(@"NSURLSessionUploadTask");
   if (nsurlsessionClass && !bit_isRunningInAppExtension()) {
     NSURLSessionConfiguration *sessionConfiguration = [NSURLSessionConfiguration defaultSessionConfiguration];
-    NSURLSession *session = [NSURLSession sessionWithConfiguration:sessionConfiguration];
+    __block NSURLSession *session = [NSURLSession sessionWithConfiguration:sessionConfiguration];
     
     NSURLRequest *request = [self requestWithBoundary:kBITHockeyAppClientBoundary];
     NSData *data = [self postBodyWithXML:xml attachment:attachment boundary:kBITHockeyAppClientBoundary];
@@ -1675,6 +1675,8 @@ static void uncaught_cxx_exception_handler(const BITCrashUncaughtCXXExceptionInf
                                                                  fromData:data
                                                         completionHandler:^(NSData *responseData, NSURLResponse *response, NSError *error) {
                                                           typeof (self) strongSelf = weakSelf;
+                                                          
+                                                          [session finishTasksAndInvalidate];
                                                           
                                                           NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*) response;
                                                           NSInteger statusCode = [httpResponse statusCode];

--- a/Classes/BITFeedbackListViewController.m
+++ b/Classes/BITFeedbackListViewController.m
@@ -720,11 +720,14 @@
         id nsurlsessionClass = NSClassFromString(@"NSURLSessionDataTask");
         if (nsurlsessionClass && !bit_isRunningInAppExtension()) {
           NSURLSessionConfiguration *sessionConfiguration = [NSURLSessionConfiguration defaultSessionConfiguration];
-          NSURLSession *session = [NSURLSession sessionWithConfiguration:sessionConfiguration];
+          __block NSURLSession *session = [NSURLSession sessionWithConfiguration:sessionConfiguration];
           
           NSURLSessionDataTask *task = [session dataTaskWithRequest:request
                                                   completionHandler: ^(NSData *data, NSURLResponse *response, NSError *error) {
                                                     typeof (self) strongSelf = weakSelf;
+                                                    
+                                                    [session finishTasksAndInvalidate];
+                                                    
                                                     [strongSelf handleResponseForAttachment:attachment responseData:data error:error];
                                                   }];
           [task resume];
@@ -991,12 +994,15 @@
       id nsurlsessionClass = NSClassFromString(@"NSURLSessionDataTask");
       if (nsurlsessionClass && !bit_isRunningInAppExtension()) {
         NSURLSessionConfiguration *sessionConfiguration = [NSURLSessionConfiguration defaultSessionConfiguration];
-        NSURLSession *session = [NSURLSession sessionWithConfiguration:sessionConfiguration];
+        __block NSURLSession *session = [NSURLSession sessionWithConfiguration:sessionConfiguration];
         
         NSURLSessionDataTask *task = [session dataTaskWithRequest:request
                                                 completionHandler: ^(NSData *data, NSURLResponse *response, NSError *error) {
                                                   dispatch_async(dispatch_get_main_queue(), ^{
                                                     typeof (self) strongSelf = weakSelf;
+                                                    
+                                                    [session finishTasksAndInvalidate];
+                                                    
                                                     [strongSelf previewController:blockController updateAttachment:attachment data:data];
                                                   });
                                                 }];

--- a/Classes/BITFeedbackManager.m
+++ b/Classes/BITFeedbackManager.m
@@ -950,11 +950,14 @@ NSString *const kBITFeedbackUpdateAttachmentThumbnail = @"BITFeedbackUpdateAttac
   id nsurlsessionClass = NSClassFromString(@"NSURLSessionDataTask");
   if (nsurlsessionClass && !bit_isRunningInAppExtension()) {
     NSURLSessionConfiguration *sessionConfiguration = [NSURLSessionConfiguration defaultSessionConfiguration];
-    NSURLSession *session = [NSURLSession sessionWithConfiguration:sessionConfiguration];
+    __block NSURLSession *session = [NSURLSession sessionWithConfiguration:sessionConfiguration];
     
     NSURLSessionDataTask *task = [session dataTaskWithRequest:request
                                             completionHandler: ^(NSData *data, NSURLResponse *response, NSError *error) {
                                               typeof (self) strongSelf = weakSelf;
+                                              
+                                              [session finishTasksAndInvalidate];
+                                              
                                               [strongSelf handleFeedbackMessageResponse:response data:data error:error completion:completionHandler];
                                             }];
     [task resume];

--- a/Classes/BITHockeyManager.m
+++ b/Classes/BITHockeyManager.m
@@ -545,10 +545,12 @@ bitstadium_info_t bitstadium_library_info __attribute__((section("__TEXT,__bit_h
   id nsurlsessionClass = NSClassFromString(@"NSURLSessionUploadTask");
   if (nsurlsessionClass && !bit_isRunningInAppExtension()) {
     NSURLSessionConfiguration *sessionConfiguration = [NSURLSessionConfiguration defaultSessionConfiguration];
-    NSURLSession *session = [NSURLSession sessionWithConfiguration:sessionConfiguration];
+    __block NSURLSession *session = [NSURLSession sessionWithConfiguration:sessionConfiguration];
     NSURLRequest *request = [[self hockeyAppClient] requestWithMethod:@"POST" path:integrationPath parameters:params];
     NSURLSessionDataTask *task = [session dataTaskWithRequest:request
                                             completionHandler: ^(NSData *data, NSURLResponse *response, NSError *error) {
+                                              [session finishTasksAndInvalidate];
+                                              
                                               NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*) response;
                                               [self logPingMessageForStatusCode:httpResponse.statusCode];
                                             }];

--- a/Classes/BITStoreUpdateManager.m
+++ b/Classes/BITStoreUpdateManager.m
@@ -356,11 +356,14 @@
   id nsurlsessionClass = NSClassFromString(@"NSURLSessionUploadTask");
   if (nsurlsessionClass && !bit_isRunningInAppExtension()) {
     NSURLSessionConfiguration *sessionConfiguration = [NSURLSessionConfiguration defaultSessionConfiguration];
-    NSURLSession *session = [NSURLSession sessionWithConfiguration:sessionConfiguration];
+    __block NSURLSession *session = [NSURLSession sessionWithConfiguration:sessionConfiguration];
     
     NSURLSessionDataTask *task = [session dataTaskWithRequest:request
                                             completionHandler: ^(NSData *data, NSURLResponse *response, NSError *error) {
                                               typeof (self) strongSelf = weakSelf;
+                                              
+                                              [session finishTasksAndInvalidate];
+                                              
                                               [strongSelf handleResponeWithData:data error:error];
                                             }];
     [task resume];

--- a/Classes/BITUpdateManager.m
+++ b/Classes/BITUpdateManager.m
@@ -1205,6 +1205,8 @@ typedef NS_ENUM(NSInteger, BITUpdateAlertViewTag) {
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error {
   
   dispatch_async(dispatch_get_main_queue(), ^{
+    [session finishTasksAndInvalidate];
+    
     if(error){
       [self handleError:error];
     }else{


### PR DESCRIPTION
This should fix the issue raised in https://github.com/bitstadium/HockeySDK-iOS/issues/237

Tested the changes before the patch with Instruments and also after the patch which prooved the leaks going away.