### PR TITLE
[WIP] Fix app startup detection to make appNotTerminatingCleanlyDetection work properly

### DIFF
--- a/Classes/BITCrashManager.h
+++ b/Classes/BITCrashManager.h
@@ -257,8 +257,8 @@ typedef NS_ENUM(NSUInteger, BITCrashManagerUserInput) {
  * @see lastSessionCrashDetails
  * @see didReceiveMemoryWarningInLastSession
  * @see `BITCrashManagerDelegate considerAppNotTerminatedCleanlyReportForCrashManager:`
- * @see [Apple Technical Note TN2151](https://developer.apple.com/library/ios/technotes/tn2151/_index.html)
- * @see [Apple Technical Q&A QA1693](https://developer.apple.com/library/ios/qa/qa1693/_index.html)
+ * @see [Apple Technical Note TN2151](https://developer.apple.com/library/ios/technotes/tn2151/_index.html )
+ * @see [Apple Technical Q&A QA1693](https://developer.apple.com/library/ios/qa/qa1693/_index.html )
  */
 @property (nonatomic, assign, getter = isAppNotTerminatingCleanlyDetectionEnabled) BOOL enableAppNotTerminatingCleanlyDetection;
 

--- a/Classes/BITCrashManager.m
+++ b/Classes/BITCrashManager.m
@@ -164,6 +164,7 @@ static void uncaught_cxx_exception_handler(const BITCrashUncaughtCXXExceptionInf
   
   BOOL _didLogLowMemoryWarning;
   
+  id _appDidFinishLaunchingObserver;
   id _appDidBecomeActiveObserver;
   id _appWillTerminateObserver;
   id _appDidEnterBackgroundObserver;
@@ -427,6 +428,16 @@ static void uncaught_cxx_exception_handler(const BITCrashUncaughtCXXExceptionInf
 - (void) registerObservers {
   __weak typeof(self) weakSelf = self;
   
+  if (nil == _appDidFinishLaunchingObserver) {
+    _appDidFinishLaunchingObserver = [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidFinishLaunchingNotification
+                                                                                       object:nil
+                                                                                        queue:NSOperationQueue.mainQueue
+                                                                                   usingBlock:^(NSNotification * _Nonnull note) {
+                                                                                     typeof(self) strongSelf = weakSelf;
+                                                                                     [strongSelf appEnteredForeground];
+                                                                                   }];
+  }
+  
   if(nil == _appDidBecomeActiveObserver) {
     _appDidBecomeActiveObserver = [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidBecomeActiveNotification
                                                                                     object:nil
@@ -493,6 +504,7 @@ static void uncaught_cxx_exception_handler(const BITCrashUncaughtCXXExceptionInf
 }
 
 - (void) unregisterObservers {
+  [self unregisterObserver:_appDidFinishLaunchingObserver];
   [self unregisterObserver:_appDidBecomeActiveObserver];
   [self unregisterObserver:_appWillTerminateObserver];
   [self unregisterObserver:_appDidEnterBackgroundObserver];

--- a/Classes/BITCrashManager.m
+++ b/Classes/BITCrashManager.m
@@ -434,7 +434,9 @@ static void uncaught_cxx_exception_handler(const BITCrashUncaughtCXXExceptionInf
                                                                                         queue:NSOperationQueue.mainQueue
                                                                                    usingBlock:^(NSNotification * _Nonnull note) {
                                                                                      typeof(self) strongSelf = weakSelf;
-                                                                                     [strongSelf appEnteredForeground];
+                                                                                     if ([UIApplication sharedApplication].applicationState != UIApplicationStateBackground) {
+                                                                                       [strongSelf appEnteredForeground];
+                                                                                     }
                                                                                    }];
   }
   

--- a/Classes/BITCrashManager.m
+++ b/Classes/BITCrashManager.m
@@ -1252,12 +1252,9 @@ static void uncaught_cxx_exception_handler(const BITCrashUncaughtCXXExceptionInf
       }
     }
   }
-  
-#if !defined (HOCKEYSDK_CONFIGURATION_ReleaseCrashOnlyExtensions)
-  if ([[UIApplication sharedApplication] applicationState] == UIApplicationStateActive) {
-    [self appEnteredForeground];
-  }
-#else
+
+#if defined (HOCKEYSDK_CONFIGURATION_ReleaseCrashOnlyExtensions)
+  // In extensions, UIApplicationDidFinishLaunchingNotification will never be fired, therfore we need this fallback
   [self appEnteredForeground];
 #endif
   


### PR DESCRIPTION
Fixes #246.

While `startManager` could be called when a process is running in the background (Remote Notifications, Extensions), the UIApplicationDidFinishLaunching notification should only fire in "real" apps and not when the app launched in the background.

What happens if SDK is initialized after `applicationDidFinishLaunchingWithOptions:`?
- [ ]  Investigate cases where enabling the `appNotTerminatingCleanlyDetection` causes many false positives while running with the Simulator attached [#1929747779](https://www.wunderlist.com/#/tasks/1929747779)
- [ ]  Investigate false positives on app upgrade [#1929747786](https://www.wunderlist.com/#/tasks/1929747786)

---
### Test cases

Different test cases I could think of:
- Background location updates
- Background notifications
- Extensions
