### PR TITLE
Fix for BITCrashManager not using its serverURL property

### DIFF
--- a/Classes/BITCrashManager.m
+++ b/Classes/BITCrashManager.m
@@ -200,11 +200,14 @@ static void uncaught_cxx_exception_handler(const BITCrashUncaughtCXXExceptionInf
   id _networkDidBecomeReachableObserver;
 }
 
+@synthesize serverURL = _serverURL;
 
-- (instancetype)init {
-  if ((self = [super init])) {
+- (instancetype)initWithAppIdentifier:(NSString *)appIdentifier appEnvironment:(BITEnvironment)environment hockeyAppClient:(BITHockeyAppClient *)hockeyAppClient {
+  if ((self = [super initWithAppIdentifier:appIdentifier appEnvironment:environment])) {
     _delegate = nil;
     _isSetup = NO;
+    
+    _hockeyAppClient = hockeyAppClient;
     
     _showAlwaysButton = YES;
     _alertViewHandler = nil;
@@ -264,6 +267,12 @@ static void uncaught_cxx_exception_handler(const BITCrashUncaughtCXXExceptionInf
   [[NSUserDefaults standardUserDefaults] setInteger:crashManagerStatus forKey:kBITCrashManagerStatus];
 }
 
+- (void)setServerURL:(NSString *)serverURL {
+  if ([serverURL isEqualToString:_serverURL]) { return; }
+
+  _serverURL = serverURL;
+  self.hockeyAppClient = [[BITHockeyAppClient alloc] initWithBaseURL:[NSURL URLWithString:serverURL]];
+}
 
 #pragma mark - Private
 

--- a/Classes/BITCrashManager.m
+++ b/Classes/BITCrashManager.m
@@ -200,8 +200,6 @@ static void uncaught_cxx_exception_handler(const BITCrashUncaughtCXXExceptionInf
   id _networkDidBecomeReachableObserver;
 }
 
-@synthesize serverURL = _serverURL;
-
 - (instancetype)initWithAppIdentifier:(NSString *)appIdentifier appEnvironment:(BITEnvironment)environment hockeyAppClient:(BITHockeyAppClient *)hockeyAppClient {
   if ((self = [super initWithAppIdentifier:appIdentifier appEnvironment:environment])) {
     _delegate = nil;
@@ -268,9 +266,9 @@ static void uncaught_cxx_exception_handler(const BITCrashUncaughtCXXExceptionInf
 }
 
 - (void)setServerURL:(NSString *)serverURL {
-  if ([serverURL isEqualToString:_serverURL]) { return; }
+  if ([serverURL isEqualToString:super.serverURL]) { return; }
 
-  _serverURL = serverURL;
+  super.serverURL = serverURL;
   self.hockeyAppClient = [[BITHockeyAppClient alloc] initWithBaseURL:[NSURL URLWithString:serverURL]];
 }
 

--- a/Classes/BITCrashManagerPrivate.h
+++ b/Classes/BITCrashManagerPrivate.h
@@ -83,6 +83,8 @@
 
 #endif /* HOCKEYSDK_FEATURE_AUTHENTICATOR */
 
+- (instancetype)initWithAppIdentifier:(NSString *)appIdentifier appEnvironment:(BITEnvironment)environment hockeyAppClient:(BITHockeyAppClient *)hockeyAppClient NS_DESIGNATED_INITIALIZER;
+
 - (void)cleanCrashReports;
 
 - (NSString *)userIDForCrashReport;

--- a/Classes/BITHockeyManager.m
+++ b/Classes/BITHockeyManager.m
@@ -241,7 +241,6 @@ bitstadium_info_t bitstadium_library_info __attribute__((section("__TEXT,__bit_h
   // start CrashManager
   if (![self isCrashManagerDisabled]) {
     BITHockeyLogDebug(@"INFO: Start CrashManager");
-    [_crashManager setHockeyAppClient:[self hockeyAppClientWithServerURL:_crashManager.serverURL]];
     
 #if HOCKEYSDK_FEATURE_AUTHENTICATOR
     if (_authenticator) {
@@ -539,13 +538,6 @@ bitstadium_info_t bitstadium_library_info __attribute__((section("__TEXT,__bit_h
   return _hockeyAppClient;
 }
 
-- (BITHockeyAppClient *)hockeyAppClientWithServerURL:(NSString *)serverURL {
-  if (!serverURL || [serverURL isEqualToString:self.serverURL]) {
-    return [self hockeyAppClient];
-  }
-  return [[BITHockeyAppClient alloc] initWithBaseURL:[NSURL URLWithString:serverURL]];
-}
-
 - (NSString *)integrationFlowTimeString {
   NSString *timeString = [[NSBundle mainBundle] objectForInfoDictionaryKey:BITHOCKEY_INTEGRATIONFLOW_TIMESTAMP];
   
@@ -693,7 +685,9 @@ bitstadium_info_t bitstadium_library_info __attribute__((section("__TEXT,__bit_h
   if (_validAppIdentifier) {
 #if HOCKEYSDK_FEATURE_CRASH_REPORTER
     BITHockeyLogDebug(@"INFO: Setup CrashManager");
-    _crashManager = [[BITCrashManager alloc] initWithAppIdentifier:_appIdentifier appEnvironment:_appEnvironment];
+    _crashManager = [[BITCrashManager alloc] initWithAppIdentifier:_appIdentifier
+                                                    appEnvironment:_appEnvironment
+                                                   hockeyAppClient:[self hockeyAppClient]];
     _crashManager.delegate = _delegate;
 #endif /* HOCKEYSDK_FEATURE_CRASH_REPORTER */
     

--- a/Classes/BITHockeyManager.m
+++ b/Classes/BITHockeyManager.m
@@ -241,9 +241,7 @@ bitstadium_info_t bitstadium_library_info __attribute__((section("__TEXT,__bit_h
   // start CrashManager
   if (![self isCrashManagerDisabled]) {
     BITHockeyLogDebug(@"INFO: Start CrashManager");
-    if (!_crashManager.serverURL && _serverURL) {
-      [_crashManager setServerURL:_serverURL];
-    }
+    [_crashManager setHockeyAppClient:[self hockeyAppClientWithServerURL:_crashManager.serverURL]];
     
 #if HOCKEYSDK_FEATURE_AUTHENTICATOR
     if (_authenticator) {
@@ -541,6 +539,13 @@ bitstadium_info_t bitstadium_library_info __attribute__((section("__TEXT,__bit_h
   return _hockeyAppClient;
 }
 
+- (BITHockeyAppClient *)hockeyAppClientWithServerURL:(NSString *)serverURL {
+  if (!serverURL || [serverURL isEqualToString:self.serverURL]) {
+    return [self hockeyAppClient];
+  }
+  return [[BITHockeyAppClient alloc] initWithBaseURL:[NSURL URLWithString:serverURL]];
+}
+
 - (NSString *)integrationFlowTimeString {
   NSString *timeString = [[NSBundle mainBundle] objectForInfoDictionaryKey:BITHOCKEY_INTEGRATIONFLOW_TIMESTAMP];
   
@@ -689,7 +694,6 @@ bitstadium_info_t bitstadium_library_info __attribute__((section("__TEXT,__bit_h
 #if HOCKEYSDK_FEATURE_CRASH_REPORTER
     BITHockeyLogDebug(@"INFO: Setup CrashManager");
     _crashManager = [[BITCrashManager alloc] initWithAppIdentifier:_appIdentifier appEnvironment:_appEnvironment];
-    _crashManager.hockeyAppClient = [self hockeyAppClient];
     _crashManager.delegate = _delegate;
 #endif /* HOCKEYSDK_FEATURE_CRASH_REPORTER */
     

--- a/Support/HockeySDKTests/BITCrashManagerTests.m
+++ b/Support/HockeySDKTests/BITCrashManagerTests.m
@@ -27,12 +27,12 @@ static NSString *const kBITCrashMetaAttachment = @"BITCrashMetaAttachment";
 
 @interface BITCrashManagerTests : XCTestCase
 
+@property BITCrashManager *sut;
+
 @end
 
 
 @implementation BITCrashManagerTests {
-  BITCrashManager *_sut;
-  BITHockeyAppClient *_hockeyAppClient;
   BOOL _startManagerInitialized;
 }
 
@@ -84,6 +84,22 @@ static NSString *const kBITCrashMetaAttachment = @"BITCrashMetaAttachment";
   XCTAssertNotNil(_sut, @"Should be there");
 }
 
+#pragma mark - Getter/Setter tests
+
+- (void)testSetServerURL {
+  BITHockeyAppClient *client = self.sut.hockeyAppClient;
+  NSURL *hockeyDefaultURL = [NSURL URLWithString:BITHOCKEYSDK_URL];
+  XCTAssertEqualObjects(self.sut.hockeyAppClient.baseURL, hockeyDefaultURL);
+  
+  [self.sut setServerURL:BITHOCKEYSDK_URL];
+  XCTAssertEqual(self.sut.hockeyAppClient, client, @"HockeyAppClient should stay the same when setting same URL again");
+  XCTAssertEqualObjects(self.sut.hockeyAppClient.baseURL, hockeyDefaultURL);
+  
+  NSString *testURLString = @"http://example.com";
+  [self.sut setServerURL:testURLString];
+  XCTAssertNotEqual(self.sut.hockeyAppClient, client, @"Should have created a new instance of BITHockeyAppClient");
+  XCTAssertEqualObjects(self.sut.hockeyAppClient.baseURL, [NSURL URLWithString:testURLString]);
+}
 
 #pragma mark - Persistence tests
 

--- a/Support/HockeySDKTests/BITCrashManagerTests.m
+++ b/Support/HockeySDKTests/BITCrashManagerTests.m
@@ -40,12 +40,7 @@ static NSString *const kBITCrashMetaAttachment = @"BITCrashMetaAttachment";
   [super setUp];
   
   _startManagerInitialized = NO;
-  _sut = [[BITCrashManager alloc] initWithAppIdentifier:nil appEnvironment:BITEnvironmentOther];
-
-  _hockeyAppClient = [[BITHockeyAppClient alloc] initWithBaseURL:[NSURL URLWithString: BITHOCKEYSDK_URL]];
-  _hockeyAppClient.baseURL = [NSURL URLWithString:BITHOCKEYSDK_URL];
-  
-  [_sut setHockeyAppClient:_hockeyAppClient];
+  _sut = [[BITCrashManager alloc] initWithAppIdentifier:nil appEnvironment:BITEnvironmentOther hockeyAppClient:[[BITHockeyAppClient alloc] initWithBaseURL:[NSURL URLWithString: BITHOCKEYSDK_URL]]];
 }
 
 - (void)tearDown {


### PR DESCRIPTION
This extends PR #275 by @dsvdmeer with some additional changes.

---

I decided to use the occasion of this issue coming up to solve this in a somewhat nicer way and also add a few tests.
Functionality can be tested by:
1. Check that crashes are being sent in a regular setup without any URL changes
2. Change only the URL of `[BITHockeyManager sharedHockeyManager].crashManager` and see if crashes are sent to the new endpoint
3. Check if all of the other features still use the default URL and function properly
