### PR TITLE
[WIP] Add IdentificationTypeHockeyAppProvidedUserEmail authentication type

### DIFF
--- a/Classes/BITAuthenticationViewController.h
+++ b/Classes/BITAuthenticationViewController.h
@@ -86,9 +86,9 @@
  *                     the UI. if succeeded is NO, it shows an alertView presenting the error
  *                     given by the completion block
  */
-- (void) authenticationViewController:(UIViewController*) viewController
-        handleAuthenticationWithEmail:(NSString*) email
-                             password:(NSString*) password
-                           completion:(void(^)(BOOL succeeded, NSError *error)) completion;
+- (void)authenticationViewController:(UIViewController*) viewController
+       handleAuthenticationWithEmail:(NSString*) email
+                            password:(NSString*) password
+                          completion:(void(^)(BOOL succeeded, NSError *error)) completion;
 
 @end

--- a/Classes/BITAuthenticator.h
+++ b/Classes/BITAuthenticator.h
@@ -87,6 +87,15 @@ typedef NS_ENUM(NSUInteger, BITAuthenticatorIdentificationType) {
    * For identification purpose any HockeyApp user is allowed.
    */
   BITAuthenticatorIdentificationTypeWebAuth,
+  /**
+   * Provide the HockeyApp account email.
+   * <br/><br/>
+   * Provide an email for transparent email authentication.
+   * If restrictApplicationUsage is enabled, the provided user account has to match a
+   * registered HockeyApp user who is a member or tester of the app.
+   * For identification purpose any HockeyApp user is allowed.
+   */
+  BITAuthenticatorIdentificationTypeHockeyAppEmailTransparent,
 };
 
 /**
@@ -193,11 +202,22 @@ typedef NS_ENUM(NSUInteger, BITAuthenticatorAppRestrictionEnforcementFrequency) 
  * "Secret:".
  *
  * This is only needed if `identificationType` is set to `BITAuthenticatorIdentificationTypeHockeyAppEmail`
+ * or `BITAuthenticatorIdentificationTypeHockeyAppEmailTransparent`.
  *
  * @see identificationType
  */
 @property (nonatomic, copy) NSString *authenticationSecret;
 
+/**
+ * The approved email to use for transparent email verification. To find the right secret,
+ * click on your app on the HockeyApp dashboard, then on Show next to
+ * "Secret:".
+ *
+ * This is only needed if `identificationType` is set to `BITAuthenticatorIdentificationTypeHockeyAppEmailTransparent`
+ *
+ * @see identificationType
+ */
+@property (nonatomic, assign) NSString *providedEmail;
 
 #pragma mark - Device based identification
 

--- a/Classes/BITAuthenticator.h
+++ b/Classes/BITAuthenticator.h
@@ -27,7 +27,6 @@
  */
 
 #import <Foundation/Foundation.h>
-
 #import "BITHockeyBaseManager.h"
 
 /**
@@ -42,7 +41,7 @@ typedef NS_ENUM(NSUInteger, BITAuthenticatorIdentificationType) {
    * to identify who actually is running this installation and on which device
    * the app is installed.
    */
-  BITAuthenticatorIdentificationTypeAnonymous,
+    BITAuthenticatorIdentificationTypeAnonymous,
   /**
    * Ask for the HockeyApp account email
    * <br/><br/>
@@ -52,16 +51,16 @@ typedef NS_ENUM(NSUInteger, BITAuthenticatorIdentificationType) {
    * The provided email address has to match an email address of a registered
    * HockeyApp user who is a member or tester of the app
    */
-  BITAuthenticatorIdentificationTypeHockeyAppEmail,
+    BITAuthenticatorIdentificationTypeHockeyAppEmail,
   /**
    * Provide the HockeyApp account email.
    * <br/><br/>
-   * Provide an email for transparent email authentication.
+   * Provide an email for email authentication via `BITHockeyManagerDelegate` or `userEmail` property.
    * If restrictApplicationUsage is enabled, the provided user account has to match a
    * registered HockeyApp user who is a member or tester of the app.
    * For identification purpose any HockeyApp user is allowed.
    */
-  BITAuthenticatorIdentificationTypeHockeyAppEmailTransparent,
+    BITAuthenticatorIdentificationTypeHockeyAppProvidedUserEmail,
   /**
    * Ask for the HockeyApp account by email and password
    * <br/><br/>
@@ -71,7 +70,7 @@ typedef NS_ENUM(NSUInteger, BITAuthenticatorIdentificationType) {
    * The provided user account has to match a registered HockeyApp user who is
    * a member or tester of the app
    */
-  BITAuthenticatorIdentificationTypeHockeyAppUser,
+    BITAuthenticatorIdentificationTypeHockeyAppUser,
   /**
    * Identifies the current device
    * <br/><br/>
@@ -83,7 +82,7 @@ typedef NS_ENUM(NSUInteger, BITAuthenticatorIdentificationType) {
    * This requires the app to register an URL scheme. See the linked property and methods
    * for further documentation on this.
    */
-  BITAuthenticatorIdentificationTypeDevice,
+    BITAuthenticatorIdentificationTypeDevice,
   /**
    * Ask for the HockeyApp account email.
    * <br/><br/>
@@ -95,7 +94,7 @@ typedef NS_ENUM(NSUInteger, BITAuthenticatorIdentificationType) {
    * registered HockeyApp user who is a member or tester of the app.
    * For identification purpose any HockeyApp user is allowed.
    */
-  BITAuthenticatorIdentificationTypeWebAuth,
+    BITAuthenticatorIdentificationTypeWebAuth,
 };
 
 /**
@@ -108,11 +107,11 @@ typedef NS_ENUM(NSUInteger, BITAuthenticatorAppRestrictionEnforcementFrequency) 
   /**
    * Checks if the user is allowed to use the app at the first time a version is started
    */
-  BITAuthenticatorAppRestrictionEnforcementOnFirstLaunch,
+    BITAuthenticatorAppRestrictionEnforcementOnFirstLaunch,
   /**
    * Checks if the user is allowed to use the app every time the app becomes active
    */
-  BITAuthenticatorAppRestrictionEnforcementOnAppActive,
+    BITAuthenticatorAppRestrictionEnforcementOnAppActive,
 };
 
 @protocol BITAuthenticatorDelegate;
@@ -140,10 +139,10 @@ typedef NS_ENUM(NSUInteger, BITAuthenticatorAppRestrictionEnforcementFrequency) 
  * either once your modal view is fully presented (e.g. its `viewDidLoad:` method is processed)
  * or once your modal view is dismissed.
  */
-@interface BITAuthenticator : BITHockeyBaseManager
+@interface BITAuthenticator: BITHockeyBaseManager
+
 
 #pragma mark - Configuration
-
 
 ///-----------------------------------------------------------------------------
 /// @name Configuration
@@ -202,22 +201,12 @@ typedef NS_ENUM(NSUInteger, BITAuthenticatorAppRestrictionEnforcementFrequency) 
  * "Secret:".
  *
  * This is only needed if `identificationType` is set to `BITAuthenticatorIdentificationTypeHockeyAppEmail`
- * or `BITAuthenticatorIdentificationTypeHockeyAppEmailTransparent`.
+ * or `BITAuthenticatorIdentificationTypeHockeyAppProvidedUserEmail`.
  *
  * @see identificationType
  */
 @property (nonatomic, copy) NSString *authenticationSecret;
 
-/**
- * The approved email to use for transparent email verification. To find the right secret,
- * click on your app on the HockeyApp dashboard, then on Show next to
- * "Secret:".
- *
- * This is only needed if `identificationType` is set to `BITAuthenticatorIdentificationTypeHockeyAppEmailTransparent`
- *
- * @see identificationType
- */
-@property (nonatomic, assign) NSString *providedEmail;
 
 #pragma mark - Device based identification
 
@@ -238,7 +227,7 @@ typedef NS_ENUM(NSUInteger, BITAuthenticatorAppRestrictionEnforcementFrequency) 
  * URL to query the device's id via external webpage
  * Built with the baseURL set in `webpageURL`.
  */
-- (NSURL*) deviceAuthenticationURL;
+- (NSURL *)deviceAuthenticationURL;
 
 /**
  * The url-scheme used to identify via `BITAuthenticatorIdentificationTypeDevice`
@@ -289,9 +278,10 @@ typedef NS_ENUM(NSUInteger, BITAuthenticatorAppRestrictionEnforcementFrequency) 
  @see identificationType
  @see urlScheme
  */
-- (BOOL) handleOpenURL:(NSURL *) url
-     sourceApplication:(NSString *) sourceApplication
-            annotation:(id) annotation;
+- (BOOL)handleOpenURL:(NSURL *)url
+    sourceApplication:(NSString *)sourceApplication
+           annotation:(id)annotation;
+
 
 #pragma mark - Authentication
 
@@ -317,7 +307,7 @@ typedef NS_ENUM(NSUInteger, BITAuthenticatorAppRestrictionEnforcementFrequency) 
  *
  * @see identificationType
  */
-- (void) authenticateInstallation;
+- (void)authenticateInstallation;
 
 /**
  * Identifies the user according to the type specified in `identificationType`.
@@ -335,7 +325,7 @@ typedef NS_ENUM(NSUInteger, BITAuthenticatorAppRestrictionEnforcementFrequency) 
  *
  * @param completion Block being executed once identification completed. Be sure to properly dispatch code to the main queue if necessary.
  */
-- (void) identifyWithCompletion:(void(^)(BOOL identified, NSError *error)) completion;
+- (void)identifyWithCompletion:(void (^)(BOOL identified, NSError *error))completion;
 
 /**
  * Returns YES if this app is identified according to the setting in `identificationType`.
@@ -364,7 +354,7 @@ typedef NS_ENUM(NSUInteger, BITAuthenticatorAppRestrictionEnforcementFrequency) 
  *
  * @param completion Block being executed once validation completed. Be sure to properly dispatch code to the main queue if necessary.
  */
-- (void) validateWithCompletion:(void(^)(BOOL validated, NSError *error)) completion;
+- (void)validateWithCompletion:(void (^)(BOOL validated, NSError *error))completion;
 
 /**
  * Indicates if this installation is validated.
@@ -374,7 +364,7 @@ typedef NS_ENUM(NSUInteger, BITAuthenticatorAppRestrictionEnforcementFrequency) 
 /**
  * Removes all previously stored authentication tokens, UDIDs, etc.
  */
-- (void) cleanupInternalStorage;
+- (void)cleanupInternalStorage;
 
 /**
  * Returns different values depending on `identificationType`. This can be used 
@@ -382,17 +372,20 @@ typedef NS_ENUM(NSUInteger, BITAuthenticatorAppRestrictionEnforcementFrequency) 
  *
  * @see identificationType
  */
-- (NSString*) publicInstallationIdentifier;
+- (NSString *)publicInstallationIdentifier;
+
 @end
+
 
 #pragma mark - Protocol
 
 /**
  * `BITAuthenticator` protocol
  */
-@protocol BITAuthenticatorDelegate <NSObject>
+@protocol BITAuthenticatorDelegate<NSObject>
 
 @optional
+
 /**
  * If the authentication (or validation) needs to identify the user,
  * this delegate method is called with the viewController that we'll present.
@@ -401,5 +394,6 @@ typedef NS_ENUM(NSUInteger, BITAuthenticatorAppRestrictionEnforcementFrequency) 
  * @param viewController `UIViewController` used to identify the user
  *
  */
-- (void) authenticator:(BITAuthenticator *)authenticator willShowAuthenticationController:(UIViewController*) viewController;
+- (void)authenticator:(BITAuthenticator *)authenticator willShowAuthenticationController:(UIViewController *)viewController;
+
 @end

--- a/Classes/BITAuthenticator.h
+++ b/Classes/BITAuthenticator.h
@@ -54,6 +54,15 @@ typedef NS_ENUM(NSUInteger, BITAuthenticatorIdentificationType) {
    */
   BITAuthenticatorIdentificationTypeHockeyAppEmail,
   /**
+   * Provide the HockeyApp account email.
+   * <br/><br/>
+   * Provide an email for transparent email authentication.
+   * If restrictApplicationUsage is enabled, the provided user account has to match a
+   * registered HockeyApp user who is a member or tester of the app.
+   * For identification purpose any HockeyApp user is allowed.
+   */
+  BITAuthenticatorIdentificationTypeHockeyAppEmailTransparent,
+  /**
    * Ask for the HockeyApp account by email and password
    * <br/><br/>
    * This will present a user interface requesting the user to provide their
@@ -87,15 +96,6 @@ typedef NS_ENUM(NSUInteger, BITAuthenticatorIdentificationType) {
    * For identification purpose any HockeyApp user is allowed.
    */
   BITAuthenticatorIdentificationTypeWebAuth,
-  /**
-   * Provide the HockeyApp account email.
-   * <br/><br/>
-   * Provide an email for transparent email authentication.
-   * If restrictApplicationUsage is enabled, the provided user account has to match a
-   * registered HockeyApp user who is a member or tester of the app.
-   * For identification purpose any HockeyApp user is allowed.
-   */
-  BITAuthenticatorIdentificationTypeHockeyAppEmailTransparent,
 };
 
 /**

--- a/Classes/BITAuthenticator.m
+++ b/Classes/BITAuthenticator.m
@@ -73,7 +73,7 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
   self = [super initWithAppIdentifier:appIdentifier appEnvironment:environment];
   if (self) {
     _webpageURL = [NSURL URLWithString:@"https://rink.hockeyapp.net/"];
-    
+
     _identificationType = BITAuthenticatorIdentificationTypeAnonymous;
     _isSetup = NO;
     _restrictApplicationUsage = NO;
@@ -100,7 +100,7 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
 - (void)authenticateInstallation {
   //disabled in TestFlight and the AppStore
   if (self.appEnvironment != BITEnvironmentOther) { return; }
-  
+
   // make sure this is called after startManager so all modules are fully setup
   if (!_isSetup) {
     [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(authenticateInstallation) object:nil];
@@ -148,21 +148,21 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
     BITHockeyLogDebug(@"Identification type mismatch for stored auth-token. Resetting.");
     [self storeInstallationIdentifier:nil withType:BITAuthenticatorIdentificationTypeAnonymous];
   }
-  
+
   NSString *identification = [self installationIdentifier];
-  
+
   if (identification) {
     self.identified = YES;
     if (completion) { completion(YES, nil); }
     return;
   }
-  
+
   [self processFullSizeImage];
   if (self.identified) {
     if (completion) { completion(YES, nil); }
     return;
   }
-  
+
   //it's not identified yet, do it now
   BITAuthenticationViewController *viewController = nil;
   switch (self.identificationType) {
@@ -214,13 +214,13 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
       [self handleAuthenticationWithEmail:[self providedEmail] password:nil completion:completion];
       return;
   }
-  
+
   if ([self.delegate respondsToSelector:@selector(authenticator:willShowAuthenticationController:)]) {
     [self.delegate authenticator:self willShowAuthenticationController:viewController];
   }
-  
+
   NSAssert(viewController, @"ViewController should've been created");
-  
+
   viewController.email = [self stringValueFromKeychainForKey:kBITAuthenticatorUserEmailKey];
   self.authenticationController = viewController;
   self.identificationCompletion = completion;
@@ -339,20 +339,20 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
     }
     return;
   }
-  
+
   NSString *validationPath = [NSString stringWithFormat:@"api/3/apps/%@/identity/validate", self.encodedAppIdentifier];
   __weak typeof(self) weakSelf = self;
   if ([BITHockeyHelper isURLSessionSupported]) {
     NSURLRequest *request = [self.hockeyAppClient requestWithMethod:@"GET" path:validationPath parameters:[self validationParameters]];
-    
+
     NSURLSessionConfiguration *sessionConfiguration = [NSURLSessionConfiguration defaultSessionConfiguration];
     __block NSURLSession *session = [NSURLSession sessionWithConfiguration:sessionConfiguration];
     NSURLSessionDataTask *task = [session dataTaskWithRequest:request
                                             completionHandler:^(NSData *data, NSURLResponse *response, NSError *dataTaskError) {
-                                              typeof (self) strongSelf = weakSelf;
-                                              
+                                              typeof(self) strongSelf = weakSelf;
+
                                               [session finishTasksAndInvalidate];
-                                              
+
                                               [strongSelf handleValidationResponseWithData:data error:dataTaskError completion:completion];
                                             }];
     [task resume];
@@ -375,8 +375,8 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
       userInfo = dict;
     }
     NSError *authenticationError = [NSError errorWithDomain:kBITAuthenticatorErrorDomain
-                                         code:BITAuthenticatorNetworkError
-                                     userInfo:userInfo];
+                                                       code:BITAuthenticatorNetworkError
+                                                   userInfo:userInfo];
     self.validated = NO;
     if (completion) { completion(NO, authenticationError); }
   } else {
@@ -393,18 +393,18 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
 - (NSDictionary *)validationParameters {
   NSParameterAssert(self.installationIdentifier);
   NSParameterAssert(self.installationIdentifierParameterString);
-  
+
   NSString *installString = bit_appAnonID(NO);
   if (installString) {
-    return @{self.installationIdentifierParameterString:self.installationIdentifier, @"install_string":installString};
+    return @{self.installationIdentifierParameterString : self.installationIdentifier, @"install_string" : installString};
   }
-  
-  return @{self.installationIdentifierParameterString:self.installationIdentifier};
+
+  return @{self.installationIdentifierParameterString : self.installationIdentifier};
 }
 
 + (BOOL)isValidationResponseValid:(id)response error:(NSError **)error {
   NSParameterAssert(response);
-  
+
   NSError *jsonParseError = nil;
   id jsonObject = [NSJSONSerialization JSONObjectWithData:response
                                                   options:0
@@ -425,7 +425,7 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
     }
     return NO;
   }
-  
+
   NSString *status = jsonObject[@"status"];
   if ([status isEqualToString:@"not authorized"]) {
     if (error) {
@@ -456,14 +456,14 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
 #pragma mark - App Provided Authentication Parameters
 
 - (void)handleAuthenticationWithEmail:(NSString *)email
-                            password:(NSString *)password
-                          completion:(void (^)(BOOL, NSError *))completion {
+                             password:(NSString *)password
+                           completion:(void (^)(BOOL, NSError *))completion {
   [self authenticationViewController:nil handleAuthenticationWithEmail:email password:password completion:completion];
 }
 
 - (void)handleAuthenticationWithEmail:(NSString *)email
-                             request:(NSURLRequest *)request
-                          completion:(void (^)(BOOL, NSError *))completion {
+                              request:(NSURLRequest *)request
+                           completion:(void (^)(BOOL, NSError *))completion {
   [self authenticationViewController:nil
        handleAuthenticationWithEmail:email
                              request:request
@@ -500,9 +500,8 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
   
   NSParameterAssert(email && email.length);
   NSParameterAssert((self.identificationType == BITAuthenticatorIdentificationTypeHockeyAppEmail) ||
-                    (self.identificationType == BITAuthenticatorIdentificationTypeHockeyAppEmailTransparent) ||
-                    (password && password.length));
-  
+      (self.identificationType == BITAuthenticatorIdentificationTypeHockeyAppEmailTransparent) ||
+      (password && password.length));
   NSURLRequest *request = [self requestForAuthenticationEmail:email password:password];
 
   [self authenticationViewController:viewController handleAuthenticationWithEmail:email request:request completion:completion];
@@ -518,14 +517,14 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
   if ([BITHockeyHelper isURLSessionSupported]) {
     NSURLSessionConfiguration *sessionConfiguration = [NSURLSessionConfiguration defaultSessionConfiguration];
     __block NSURLSession *session = [NSURLSession sessionWithConfiguration:sessionConfiguration];
-    
+
     NSURLSessionDataTask *task = [session dataTaskWithRequest:request
                                             completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
                                               typeof(self) strongSelf = weakSelf;
                                               NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
-                                              
+
                                               [session finishTasksAndInvalidate];
-                                              
+
                                               [strongSelf handleAuthenticationWithResponse:httpResponse email:email data:data completion:completion];
                                             }];
     [task resume];
@@ -537,7 +536,7 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
                                                                                                               email:email
                                                                                                                data:responseData
                                                                                                          completion:completion];
-                                                                     }];
+                                                                        }];
     [self.hockeyAppClient enqeueHTTPOperation:newOperation];
   }
 }
@@ -581,21 +580,21 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
 - (NSURLRequest *)requestForAuthenticationEmail:(NSString *)email password:(NSString *)password {
   NSString *authenticationPath = [self authenticationPath];
   NSMutableDictionary *params = [NSMutableDictionary dictionary];
-  
+
   NSString *installString = bit_appAnonID(NO);
   if (installString) {
     params[@"install_string"] = installString;
   }
-  
+
   if (BITAuthenticatorIdentificationTypeHockeyAppEmail == self.identificationType || BITAuthenticatorIdentificationTypeHockeyAppEmailTransparent == self.identificationType) {
     NSString *authCode = BITHockeyMD5([NSString stringWithFormat:@"%@%@",
-                                       self.authenticationSecret ?: @"",
-                                       email ?: @""]);
-    
+                                                                 self.authenticationSecret ?: @"",
+                                                                 email ?: @""]);
+
     params[@"email"] = email ?: @"";
     params[@"authcode"] = authCode.lowercaseString;
   }
-  
+
   NSMutableURLRequest *request = [self.hockeyAppClient requestWithMethod:@"POST"
                                                                     path:authenticationPath
                                                               parameters:params];
@@ -605,7 +604,7 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
     NSString *authValue = [NSString stringWithFormat:@"Basic %@", bit_base64String(authData, authData.length)];
     [request setValue:authValue forHTTPHeaderField:@"Authorization"];
   }
-  
+
   return request;
 }
 
@@ -622,19 +621,19 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
     if (error) {
       *error = [NSError errorWithDomain:kBITAuthenticatorErrorDomain
                                    code:BITAuthenticatorAPIServerReturnedInvalidResponse
-                               userInfo:@{NSLocalizedDescriptionKey:BITHockeyLocalizedString(@"HockeyAuthenticationFailedAuthenticate")}];
+                               userInfo:@{NSLocalizedDescriptionKey : BITHockeyLocalizedString(@"HockeyAuthenticationFailedAuthenticate")}];
     }
     return nil;
   }
-  
-  switch (urlResponse.statusCode) {
+
+  switch(urlResponse.statusCode) {
     case 401:
       if (error) {
         *error = [NSError errorWithDomain:kBITAuthenticatorErrorDomain
                                      code:BITAuthenticatorNotAuthorized
                                  userInfo:@{
-                                            NSLocalizedDescriptionKey:BITHockeyLocalizedString(@"HockeyAuthenticationWrongEmailPassword")
-                                            }];
+                                     NSLocalizedDescriptionKey : BITHockeyLocalizedString(@"HockeyAuthenticationWrongEmailPassword")
+                                 }];
       }
       break;
     case 200:
@@ -645,8 +644,8 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
       if (error) {
         *error = [NSError errorWithDomain:kBITAuthenticatorErrorDomain
                                      code:BITAuthenticatorAPIServerReturnedInvalidResponse
-                                 userInfo:@{NSLocalizedDescriptionKey:BITHockeyLocalizedString(@"HockeyAuthenticationFailedAuthenticate")}];
-        
+                                 userInfo:@{NSLocalizedDescriptionKey : BITHockeyLocalizedString(@"HockeyAuthenticationFailedAuthenticate")}];
+
       }
       break;
   }
@@ -655,7 +654,7 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
     NSParameterAssert(nil == error || *error);
     return nil;
   }
-  
+
   NSError *jsonParseError = nil;
   id jsonObject = [NSJSONSerialization JSONObjectWithData:data
                                                   options:0
@@ -663,7 +662,7 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
   //no json or unexpected json
   if (nil == jsonObject || ![jsonObject isKindOfClass:[NSDictionary class]]) {
     if (error) {
-      NSDictionary *userInfo = @{NSLocalizedDescriptionKey:BITHockeyLocalizedString(@"HockeyAuthenticationFailedAuthenticate")};
+      NSDictionary *userInfo = @{NSLocalizedDescriptionKey : BITHockeyLocalizedString(@"HockeyAuthenticationFailedAuthenticate")};
       if (jsonParseError) {
         NSMutableDictionary *userInfoMutable = [userInfo mutableCopy];
         userInfoMutable[NSUnderlyingErrorKey] = jsonParseError;
@@ -675,7 +674,7 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
     }
     return nil;
   }
-  
+
   NSString *status = jsonObject[@"status"];
   NSString *authToken = nil;
   if ([status isEqualToString:@"identified"]) {
@@ -686,15 +685,15 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
     if (error) {
       *error = [NSError errorWithDomain:kBITAuthenticatorErrorDomain
                                    code:BITAuthenticatorNotAuthorized
-                               userInfo:@{NSLocalizedDescriptionKey:BITHockeyLocalizedString(@"HockeyAuthenticationNotMember")}];
-      
+                               userInfo:@{NSLocalizedDescriptionKey : BITHockeyLocalizedString(@"HockeyAuthenticationNotMember")}];
+
     }
   }
   //if no error is set yet, but error parameter is given, return a generic error
   if (nil == authToken && error && nil == *error) {
     *error = [NSError errorWithDomain:kBITAuthenticatorErrorDomain
                                  code:BITAuthenticatorAPIServerReturnedInvalidResponse
-                             userInfo:@{NSLocalizedDescriptionKey:BITHockeyLocalizedString(@"HockeyAuthenticationFailedAuthenticate")}];
+                             userInfo:@{NSLocalizedDescriptionKey : BITHockeyLocalizedString(@"HockeyAuthenticationFailedAuthenticate")}];
   }
   return authToken;
 }
@@ -731,7 +730,7 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
     BITHockeyLogWarning(@"WARNING: URL scheme for authentication doesn't match!");
     return NO;
   }
-  
+
   NSString *installationIdentifier = nil;
   NSString *localizedErrorDescription = nil;
   switch (self.identificationType) {
@@ -760,7 +759,7 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
     case BITAuthenticatorIdentificationTypeHockeyAppUser:
       return NO;
   }
-  
+
   if (installationIdentifier) {
     BITHockeyLogDebug(@"Authentication succeeded.");
     if (NO == self.restrictApplicationUsage) {
@@ -839,7 +838,7 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
   [self removeKeyFromKeychain:kBITAuthenticatorUUIDKey];
   [self removeKeyFromKeychain:kBITAuthenticatorUserEmailKey];
   [self setLastAuthenticatedVersion:nil];
-  
+
   //cleanup values stored from 3.5 Beta1..Beta3
   [self removeKeyFromKeychain:kBITAuthenticatorAuthTokenKey];
   [self removeKeyFromKeychain:kBITAuthenticatorAuthTokenTypeKey];
@@ -851,7 +850,7 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
 #else
   NSString *path = [[[NSBundle mainBundle] bundlePath] stringByAppendingString:@"/../iTunesArtwork"];
 #endif
-  
+
   struct stat fs;
   int fd = open([path UTF8String], O_RDONLY, 0);
   if (fstat(fd, &fs) < 0) {
@@ -859,9 +858,9 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
     close(fd);
     return;
   }
-  
+
   BITHockeyLogDebug(@"Processing full size image for possible authentication");
-  
+
   unsigned char *buffer, *source;
   source = (unsigned char *)malloc((unsigned long)fs.st_size);
   if (read(fd, source, (unsigned long)fs.st_size) != fs.st_size) {
@@ -870,15 +869,15 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
     free(source);
     return;
   }
-  
+
   if ((fs.st_size < 20) || (memcmp(source, kBITPNGHeader, 8))) {
     // Not a PNG
     free(source);
     return;
   }
-  
+
   buffer = source + 8;
-  
+
   NSString *result = nil;
   bit_uint32 length;
   unsigned char *name;
@@ -888,42 +887,42 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
   do {
     memcpy(&length, buffer, 4);
     length = ntohl(length);
-    
+
     buffer += 4;
     name = (unsigned char *)malloc(5);
     name[4] = 0;
     memcpy(name, buffer, 4);
-    
+
     buffer += 4;
     data = (unsigned char *)malloc(length + 1);
-    
+
     if (bytes_left >= length) {
       memcpy(data, buffer, length);
-      
+
       buffer += length;
       buffer += 4;
       if (!strcmp((const char *)name, "tEXt")) {
         data[length] = 0;
         NSString *key = [NSString stringWithCString:(char *)data encoding:NSUTF8StringEncoding];
-        
+
         if ([key isEqualToString:@"Data"]) {
           result = [NSString stringWithCString:(char *)(data + key.length + 1) encoding:NSUTF8StringEncoding];
         }
       }
-      
+
       if (!memcmp(name, kBITPNGEndChunk, 4)) {
         chunk_index = 128;
       }
     }
-    
+
     free(data);
     free(name);
-    
+
     bytes_left -= (length + 3 * 4);
   } while ((chunk_index++ < 128) && (bytes_left > 8));
-  
+
   free(source);
-  
+
   if (result) {
     BITHockeyLogDebug(@"Authenticating using full size image information: %@", result);
     [self handleOpenURL:[NSURL URLWithString:result] sourceApplication:nil annotation:nil];
@@ -1023,8 +1022,8 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
 
 + (NSString *)stringForIdentificationType:(BITAuthenticatorIdentificationType)identificationType {
   switch (identificationType) {
-    case BITAuthenticatorIdentificationTypeHockeyAppEmailTransparent:
     case BITAuthenticatorIdentificationTypeHockeyAppEmail:
+    case BITAuthenticatorIdentificationTypeHockeyAppEmailTransparent:
       return @"iuid";
     case BITAuthenticatorIdentificationTypeWebAuth:
       return @"webAuth";

--- a/Classes/BITAuthenticator.m
+++ b/Classes/BITAuthenticator.m
@@ -306,7 +306,7 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
       break;
     }
     case BITAuthenticatorIdentificationTypeHockeyAppEmail:
-      if(nil == self.authenticationSecret) {
+      if (nil == self.authenticationSecret) {
         error = [NSError errorWithDomain:kBITAuthenticatorErrorDomain
                                     code:BITAuthenticatorAuthorizationSecretMissing
                                 userInfo:@{NSLocalizedDescriptionKey : @"For email validation, the authentication secret must be set"}];

--- a/Classes/BITAuthenticator.m
+++ b/Classes/BITAuthenticator.m
@@ -298,19 +298,19 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
       requirementsFulfilled = NO;
       break;
     }
-    case BITAuthenticatorIdentificationTypeHockeyAppEmailTransparent:
+    case BITAuthenticatorIdentificationTypeHockeyAppEmail:
       if(nil == self.authenticationSecret) {
         error = [NSError errorWithDomain:kBITAuthenticatorErrorDomain
-                                    code:BITAuthenticatorEmailMissing
-                                userInfo:@{NSLocalizedDescriptionKey : @"For transparent email validation, the provided email must be set"}];
+                                    code:BITAuthenticatorAuthorizationSecretMissing
+                                userInfo:@{NSLocalizedDescriptionKey : @"For email validation, the authentication secret must be set"}];
         requirementsFulfilled = NO;
         break;
       }
-    case BITAuthenticatorIdentificationTypeHockeyAppEmail:
-      if (nil == self.authenticationSecret) {
+    case BITAuthenticatorIdentificationTypeHockeyAppEmailTransparent:
+      if ((nil == self.authenticationSecret) || (nil == self.providedEmail)) {
         error = [NSError errorWithDomain:kBITAuthenticatorErrorDomain
-                                    code:BITAuthenticatorAuthorizationSecretMissing
-                                userInfo:@{NSLocalizedDescriptionKey:@"For email validation, the authentication secret must be set"}];
+                                    code:BITAuthenticatorEmailMissing
+                                userInfo:@{NSLocalizedDescriptionKey : @"For transparent email validation, the authentication secret and provided email must be set"}];
         requirementsFulfilled = NO;
         break;
       }
@@ -700,9 +700,9 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
     case BITAuthenticatorIdentificationTypeDevice:
       whatParameter = @"udid";
       break;
-    case BITAuthenticatorIdentificationTypeHockeyAppEmailTransparent:
     case BITAuthenticatorIdentificationTypeAnonymous:
     case BITAuthenticatorIdentificationTypeHockeyAppEmail:
+    case BITAuthenticatorIdentificationTypeHockeyAppEmailTransparent:
     case BITAuthenticatorIdentificationTypeHockeyAppUser:
       return nil;
       break;
@@ -747,8 +747,8 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
       localizedErrorDescription = @"Failed to retrieve UDID from URL.";
       break;
     }
-    case BITAuthenticatorIdentificationTypeHockeyAppEmailTransparent:
     case BITAuthenticatorIdentificationTypeHockeyAppEmail:
+    case BITAuthenticatorIdentificationTypeHockeyAppEmailTransparent:
     case BITAuthenticatorIdentificationTypeAnonymous:
     case BITAuthenticatorIdentificationTypeHockeyAppUser:
       return NO;
@@ -1001,8 +1001,8 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
 
 - (NSString *)installationIdentifierParameterString {
   switch (self.identificationType) {
-    case BITAuthenticatorIdentificationTypeHockeyAppEmailTransparent:
     case BITAuthenticatorIdentificationTypeHockeyAppEmail:
+    case BITAuthenticatorIdentificationTypeHockeyAppEmailTransparent:
     case BITAuthenticatorIdentificationTypeWebAuth:
       return @"iuid";
     case BITAuthenticatorIdentificationTypeHockeyAppUser:
@@ -1040,8 +1040,8 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
 
 - (NSString *)publicInstallationIdentifier {
   switch (self.identificationType) {
-    case BITAuthenticatorIdentificationTypeHockeyAppEmailTransparent:
     case BITAuthenticatorIdentificationTypeHockeyAppEmail:
+    case BITAuthenticatorIdentificationTypeHockeyAppEmailTransparent:
     case BITAuthenticatorIdentificationTypeHockeyAppUser:
     case BITAuthenticatorIdentificationTypeWebAuth:
       return [self stringValueFromKeychainForKey:kBITAuthenticatorUserEmailKey];

--- a/Classes/BITAuthenticator.m
+++ b/Classes/BITAuthenticator.m
@@ -204,7 +204,14 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
         if (completion) { completion(NO, error); }
         return;
       }
-      [self handleAuthenticationWithEmail:[self providedEmail] password:@"" completion:completion];
+      if (nil == self.providedEmail) {
+        NSError *error = [NSError errorWithDomain:kBITAuthenticatorErrorDomain
+                                             code:BITAuthenticatorEmailMissing
+                                         userInfo:@{NSLocalizedDescriptionKey : @"For transparent email validation, the provided email must be set"}];
+        if (completion) { completion(NO, error); }
+        return;
+      }
+      [self handleAuthenticationWithEmail:[self providedEmail] password:nil completion:completion];
       return;
   }
   
@@ -493,7 +500,9 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
                           completion:(void (^)(BOOL, NSError *))completion {
   
   NSParameterAssert(email && email.length);
-  NSParameterAssert(self.identificationType == BITAuthenticatorIdentificationTypeHockeyAppEmail || (password && password.length));
+  NSParameterAssert((self.identificationType == BITAuthenticatorIdentificationTypeHockeyAppEmail) ||
+                    (self.identificationType == BITAuthenticatorIdentificationTypeHockeyAppEmailTransparent) ||
+                    (password && password.length));
   
   NSURLRequest *request = [self requestForAuthenticationEmail:email password:password];
 

--- a/Classes/BITAuthenticator_Private.h
+++ b/Classes/BITAuthenticator_Private.h
@@ -92,13 +92,13 @@
 @property (nonatomic, assign, readwrite, getter = isValidated) BOOL validated;
 
 #pragma mark - Testing
-- (void) storeInstallationIdentifier:(NSString*) identifier withType:(BITAuthenticatorIdentificationType) type;
+- (void)storeInstallationIdentifier:(NSString*) identifier withType:(BITAuthenticatorIdentificationType) type;
 - (void)authenticationViewController:(UIViewController *)viewController
        handleAuthenticationWithEmail:(NSString *)email
                              request:(NSURLRequest *)request
                           completion:(void (^)(BOOL, NSError *))completion;
-- (BOOL) needsValidation;
-- (void) authenticate;
+- (BOOL)needsValidation;
+- (void)authenticate;
 @end
 
 #endif /* HOCKEYSDK_FEATURE_AUTHENTICATOR */

--- a/Classes/BITAuthenticator_Private.h
+++ b/Classes/BITAuthenticator_Private.h
@@ -93,7 +93,6 @@
 
 #pragma mark - Testing
 - (void) storeInstallationIdentifier:(NSString*) identifier withType:(BITAuthenticatorIdentificationType) type;
-- (void)validateWithCompletion:(void (^)(BOOL validated, NSError *))completion;
 - (void)authenticationViewController:(UIViewController *)viewController
        handleAuthenticationWithEmail:(NSString *)email
                              request:(NSURLRequest *)request

--- a/Classes/BITHockeyManagerDelegate.h
+++ b/Classes/BITHockeyManagerDelegate.h
@@ -220,7 +220,7 @@
  are not anonymous any more and the crash alerts will not show the word "anonymous"!
 
  @param hockeyManager The `BITHockeyManager` HockeyManager instance invoking this delegate
- @param componentManager The `BITHockeyBaseManager` component instance invoking this delegate, can be `BITCrashManager` or `BITFeedbackManager`
+ @param componentManager The `BITHockeyBaseManager` component instance invoking this delegate, can be `BITAuthenticator`, `BITCrashManager` or `BITFeedbackManager`
  @see userIDForHockeyManager:componentManager:
  @see userNameForHockeyManager:componentManager:
  @see [BITHockeyManager userEmail]

--- a/Classes/HockeySDKEnums.h
+++ b/Classes/HockeySDKEnums.h
@@ -172,6 +172,10 @@ typedef NS_ENUM(NSInteger, BITAuthenticatorReason) {
    *  Not yet identified
    */
   BITAuthenticatorNotIdentified,
+  /**
+   *  Email for transparent email authentication missing
+   */
+  BITAuthenticatorEmailMissing
 };
 
 /**

--- a/Classes/HockeySDKEnums.h
+++ b/Classes/HockeySDKEnums.h
@@ -151,7 +151,6 @@ typedef NS_ENUM(NSInteger, BITAuthenticatorReason) {
    *  Network error
    */
   BITAuthenticatorNetworkError,
-  
   /**
    *  API Server returned invalid response
    */
@@ -173,9 +172,9 @@ typedef NS_ENUM(NSInteger, BITAuthenticatorReason) {
    */
   BITAuthenticatorNotIdentified,
   /**
-   *  Email for transparent email authentication missing
+   *  Email for ProvidedUserEmail authentication missing
    */
-  BITAuthenticatorEmailMissing
+  BITAuthenticatorProvidedUserEmailMissing
 };
 
 /**

--- a/Support/HockeySDKTests/BITAuthenticatorTests.m
+++ b/Support/HockeySDKTests/BITAuthenticatorTests.m
@@ -183,6 +183,7 @@ static void *kInstallationIdentification = &kInstallationIdentification;
   
   [verifyCount(delegateMock, times(1)) authenticator:_sut willShowAuthenticationController:(id)anything()];
 }
+
 #pragma mark - Web auth identification type
 - (void) testWebAuthIdentificationShowsViewController {
   _sut.identificationType = BITAuthenticatorIdentificationTypeWebAuth;
@@ -237,18 +238,18 @@ static void *kInstallationIdentification = &kInstallationIdentification;
   [verify(httpClientMock) enqeueHTTPOperation:anything()];
 }
 
-#pragma mark - Email Transparent identification type
-- (void) testEmailTransparentIdentificationFailsWithMissingSecret {
-  _sut.identificationType = BITAuthenticatorIdentificationTypeHockeyAppEmailTransparent;
-  _sut.providedEmail = @"johndoe@example.com";
+#pragma mark - ProvidedUserEmail identification type
+- (void) testProvidedUserEmailIdentificationFailsWithMissingSecret {
+  _sut.identificationType = BITAuthenticatorIdentificationTypeHockeyAppProvidedUserEmail;
+  [BITHockeyManager sharedHockeyManager].userEmail = @"johndoe@example.com";
   [_sut identifyWithCompletion:^(BOOL identified, NSError *error) {
     assertThatBool(identified, isFalse());
     assertThat(error, notNilValue());
   }];
 }
 
-- (void) testEmailTransparentIdentificationFailsWithMissingProvidedEmail {
-  _sut.identificationType = BITAuthenticatorIdentificationTypeHockeyAppEmailTransparent;
+- (void) testProvidedUserEmailIdentificationFailsWithMissingProvidedEmail {
+  _sut.identificationType = BITAuthenticatorIdentificationTypeHockeyAppProvidedUserEmail;
   _sut.authenticationSecret = @"mySecret";
   [_sut identifyWithCompletion:^(BOOL identified, NSError *error) {
     assertThatBool(identified, isFalse());
@@ -256,8 +257,8 @@ static void *kInstallationIdentification = &kInstallationIdentification;
   }];
 }
 
-- (void) testEmailTransparentIdentificationDoesntShowViewController {
-  _sut.identificationType = BITAuthenticatorIdentificationTypeHockeyAppEmailTransparent;
+- (void) testProvidedUserEmailIdentificationDoesntShowViewController {
+  _sut.identificationType = BITAuthenticatorIdentificationTypeHockeyAppProvidedUserEmail;
   _sut.authenticationSecret = @"mySecret";
   id delegateMock = mockProtocol(@protocol(BITAuthenticatorDelegate));
   _sut.delegate = delegateMock;
@@ -267,17 +268,17 @@ static void *kInstallationIdentification = &kInstallationIdentification;
   [verifyCount(delegateMock, times(0)) authenticator:_sut willShowAuthenticationController:(id)anything()];
 }
 
-- (void) testEmailTransparentValidationFailsWithMissingSecret {
-  _sut.identificationType = BITAuthenticatorIdentificationTypeHockeyAppEmailTransparent;
-  _sut.providedEmail = @"johndoe@example.com";
+- (void) testProvidedUserEmailValidationFailsWithMissingSecret {
+  _sut.identificationType = BITAuthenticatorIdentificationTypeHockeyAppProvidedUserEmail;
+  [BITHockeyManager sharedHockeyManager].userEmail = @"johndoe@example.com";
   [_sut validateWithCompletion:^(BOOL validated, NSError *error) {
     assertThatBool(validated, isFalse());
     assertThat(error, notNilValue());
   }];
 }
 
-- (void) testEmailTransparentValidationFailsWithMissingProvidedEmail {
-  _sut.identificationType = BITAuthenticatorIdentificationTypeHockeyAppEmailTransparent;
+- (void) testProvidedUserEmailValidationFailsWithMissingProvidedEmail {
+  _sut.identificationType = BITAuthenticatorIdentificationTypeHockeyAppProvidedUserEmail;
   _sut.authenticationSecret = @"mySecret";
   [_sut validateWithCompletion:^(BOOL validated, NSError *error) {
     assertThatBool(validated, isFalse());
@@ -285,13 +286,13 @@ static void *kInstallationIdentification = &kInstallationIdentification;
   }];
 }
 
-- (void) testThatEmailTransparentIdentificationQueuesAnOperation {
+- (void) testThatProvidedUserEmailIdentificationQueuesAnOperation {
   id helperMock = OCMClassMock([BITHockeyHelper class]);
   OCMStub([helperMock isURLSessionSupported]).andReturn(NO);
   
   id httpClientMock = mock(BITHockeyAppClient.class);
   _sut.hockeyAppClient = httpClientMock;
-  _sut.identificationType = BITAuthenticatorIdentificationTypeHockeyAppEmailTransparent;
+  _sut.identificationType = BITAuthenticatorIdentificationTypeHockeyAppProvidedUserEmail;
   
   [_sut authenticationViewController:nil handleAuthenticationWithEmail:@"johndoe@example.com" password:nil completion:nil];
   

--- a/Support/HockeySDKTests/BITAuthenticatorTests.m
+++ b/Support/HockeySDKTests/BITAuthenticatorTests.m
@@ -237,6 +237,67 @@ static void *kInstallationIdentification = &kInstallationIdentification;
   [verify(httpClientMock) enqeueHTTPOperation:anything()];
 }
 
+#pragma mark - Email Transparent identification type
+- (void) testEmailTransparentIdentificationFailsWithMissingSecret {
+  _sut.identificationType = BITAuthenticatorIdentificationTypeHockeyAppEmailTransparent;
+  _sut.providedEmail = @"johndoe@example.com";
+  [_sut identifyWithCompletion:^(BOOL identified, NSError *error) {
+    assertThatBool(identified, isFalse());
+    assertThat(error, notNilValue());
+  }];
+}
+
+- (void) testEmailTransparentIdentificationFailsWithMissingProvidedEmail {
+  _sut.identificationType = BITAuthenticatorIdentificationTypeHockeyAppEmailTransparent;
+  _sut.authenticationSecret = @"mySecret";
+  [_sut identifyWithCompletion:^(BOOL identified, NSError *error) {
+    assertThatBool(identified, isFalse());
+    assertThat(error, notNilValue());
+  }];
+}
+
+- (void) testEmailTransparentIdentificationDoesntShowViewController {
+  _sut.identificationType = BITAuthenticatorIdentificationTypeHockeyAppEmailTransparent;
+  _sut.authenticationSecret = @"mySecret";
+  id delegateMock = mockProtocol(@protocol(BITAuthenticatorDelegate));
+  _sut.delegate = delegateMock;
+  
+  [_sut identifyWithCompletion:nil];
+  
+  [verifyCount(delegateMock, times(0)) authenticator:_sut willShowAuthenticationController:(id)anything()];
+}
+
+- (void) testEmailTransparentValidationFailsWithMissingSecret {
+  _sut.identificationType = BITAuthenticatorIdentificationTypeHockeyAppEmailTransparent;
+  _sut.providedEmail = @"johndoe@example.com";
+  [_sut validateWithCompletion:^(BOOL validated, NSError *error) {
+    assertThatBool(validated, isFalse());
+    assertThat(error, notNilValue());
+  }];
+}
+
+- (void) testEmailTransparentValidationFailsWithMissingProvidedEmail {
+  _sut.identificationType = BITAuthenticatorIdentificationTypeHockeyAppEmailTransparent;
+  _sut.authenticationSecret = @"mySecret";
+  [_sut validateWithCompletion:^(BOOL validated, NSError *error) {
+    assertThatBool(validated, isFalse());
+    assertThat(error, notNilValue());
+  }];
+}
+
+- (void) testThatEmailTransparentIdentificationQueuesAnOperation {
+  id helperMock = OCMClassMock([BITHockeyHelper class]);
+  OCMStub([helperMock isURLSessionSupported]).andReturn(NO);
+  
+  id httpClientMock = mock(BITHockeyAppClient.class);
+  _sut.hockeyAppClient = httpClientMock;
+  _sut.identificationType = BITAuthenticatorIdentificationTypeHockeyAppEmailTransparent;
+  
+  [_sut authenticationViewController:nil handleAuthenticationWithEmail:@"johndoe@example.com" password:nil completion:nil];
+  
+  [verify(httpClientMock) enqeueHTTPOperation:anything()];
+}
+
 #pragma mark - User identification type
 - (void) testUserIdentificationShowsViewController {
   _sut.identificationType = BITAuthenticatorIdentificationTypeHockeyAppUser;


### PR DESCRIPTION
This allows to programmatically set the email address used for HockeyApp authentication, it extends the approach taken in #225.
The mechanism leverages the existing APIs like `[BITHockeyManager sharedHockeyManager].userEmail` or the `userEmailForHockeyManager:componentManager:` delegate method.

---

Questions to be answered:
- [ ]  What happens when authentication fails? [#1929747685](https://www.wunderlist.com/#/tasks/1929747685)
