### PR TITLE
[WIP] Fix authentication issues

### DIFF
--- a/Classes/BITAuthenticator.m
+++ b/Classes/BITAuthenticator.m
@@ -536,6 +536,9 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
   if (completion) { completion(identified, authParseError); }
   if (self.identificationCompletion) {
     self.identificationCompletion(identified, authParseError);
+    if (identified) {
+      self.identificationCompletion = nil;
+    }
   }
 }
 
@@ -730,6 +733,7 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
     self.identified = YES;
     if (self.identificationCompletion) {
       self.identificationCompletion(YES, nil);
+      self.identificationCompletion = nil;
     }
   } else {
     //reset token

--- a/Classes/BITAuthenticator.m
+++ b/Classes/BITAuthenticator.m
@@ -1029,7 +1029,9 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (void)alertView:(UIAlertView *)alertView didDismissWithButtonIndex:(NSInteger)buttonIndex {
   if (alertView.tag == 0) {
-    [self validate];
+    [self cleanupInternalStorage];
+    self.identified = NO;
+    [self authenticate];
   }
 }
 #pragma clang diagnostic pop

--- a/Classes/BITAuthenticator.m
+++ b/Classes/BITAuthenticator.m
@@ -536,7 +536,6 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
   if (completion) { completion(identified, authParseError); }
   if (self.identificationCompletion) {
     self.identificationCompletion(identified, authParseError);
-    self.identificationCompletion = nil;
   }
 }
 
@@ -731,7 +730,6 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
     self.identified = YES;
     if (self.identificationCompletion) {
       self.identificationCompletion(YES, nil);
-      self.identificationCompletion = nil;
     }
   } else {
     //reset token
@@ -743,7 +741,6 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
                                            code:BITAuthenticatorErrorUnknown
                                        userInfo:@{NSLocalizedDescriptionKey:localizedErrorDescription}];
       self.identificationCompletion(NO, error);
-      self.identificationCompletion = nil;
     }
   }
   return YES;


### PR DESCRIPTION
This fixes 2 issues that occur in certain scenarios:
1. When using the `identifyWithCompletion:` API, the completion handler was no longer retained if the first authentication try failed.
2. Users could get stuck in an endless loop by either using WebAuth with the wrong account or by e.g. using any other authentication mechanism where their access was removed and they would want to switch accounts.

Solutions to this:
- Only release the `identificationCompletion` block after a successful identification
- Allow users to re-enter credentials if the login failed
