### PR TITLE
Fix a bug where preparedItemsForFeedbackManager: would not work

### DIFF
--- a/Classes/BITFeedbackManager.m
+++ b/Classes/BITFeedbackManager.m
@@ -234,7 +234,7 @@ typedef void (^BITLatestImageFetchCompletionBlock)(UIImage *_Nonnull latestImage
   
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated"
-  NSArray *preparedItems = self.feedbackComposerPreparedItems;
+  NSArray *preparedItems = self.feedbackComposerPreparedItems ?: [NSArray array];
 #pragma clang diagnostic pop
   if ([self.delegate respondsToSelector:@selector(preparedItemsForFeedbackManager:)]) {
     preparedItems = [preparedItems arrayByAddingObjectsFromArray:[self.delegate preparedItemsForFeedbackManager:self]];

--- a/Support/HockeySDKTests/BITFeedbackManagerTests.m
+++ b/Support/HockeySDKTests/BITFeedbackManagerTests.m
@@ -236,24 +236,35 @@
   
   self.sut.feedbackComposeHideImageAttachmentButton = YES;
   XCTAssertTrue(self.sut.feedbackComposeHideImageAttachmentButton);
-  
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated"
-  self.sut.feedbackComposerPreparedItems = @[sampleImage1, sampleData1];
-#pragma clang diagnostic pop
 
   id<BITFeedbackManagerDelegate> mockDelegate = mockProtocol(@protocol(BITFeedbackManagerDelegate));
   [given([mockDelegate preparedItemsForFeedbackManager:self.sut]) willReturn:@[sampleImage2, sampleData2]];
   self.sut.delegate = mockDelegate;
   
+  
+  // Test when feedbackComposerPreparedItems is also set
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+  self.sut.feedbackComposerPreparedItems = @[sampleImage1, sampleData1];
+#pragma clang diagnostic pop
+  
   BITFeedbackComposeViewController *composeViewController = [self.sut feedbackComposeViewController];
-  
   NSArray *attachments = [composeViewController performSelector:@selector(attachments)];
-  
   XCTAssertEqual(attachments.count, 4);
+
+  
+  // Test when feedbackComposerPreparedItems is nil
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+  self.sut.feedbackComposerPreparedItems = nil;
+#pragma clang diagnostic pop
+  
+  composeViewController = [self.sut feedbackComposeViewController];
+  attachments = [composeViewController performSelector:@selector(attachments)];
+  XCTAssertEqual(attachments.count, 2);
+  
   
   XCTAssertTrue(composeViewController.hideImageAttachmentButton);
-  
   XCTAssertEqual(composeViewController.delegate, mockDelegate);
 }
 


### PR DESCRIPTION
Because a temporary variable was not initialized if the `feedbackComposerPreparedItems` property was nil, `preparedItemsForFeedbackManager:` would not work in those cases.

This adds a test for that case and also fixes the issue.
