### PR TITLE
Added a boolean flag to enable "one message, one thread" mode

### DIFF
--- a/Classes/BITFeedbackManager.h
+++ b/Classes/BITFeedbackManager.h
@@ -208,6 +208,14 @@ typedef NS_ENUM(NSInteger, BITFeedbackObservationMode) {
 
 
 /**
+ Define if each new feedback should start a new discussion thread in the backend.
+ 
+ Default is `NO`
+ */
+@property (nonatomic, readwrite) BOOL startNewThreadForEachFeedback;
+
+
+/**
  Define the trigger that opens the feedback composer and attaches a screenshot
  
  The following modes are available:

--- a/Classes/BITFeedbackManager.m
+++ b/Classes/BITFeedbackManager.m
@@ -878,7 +878,7 @@ typedef void (^BITLatestImageFetchCompletionBlock)(UIImage *_Nonnull latestImage
   [[NSNotificationCenter defaultCenter] postNotificationName:BITHockeyFeedbackMessagesLoadingStarted object:nil];
   
   NSString *tokenParameter = @"";
-  if ([self token]) {
+  if ([self token] && !self.startNewThreadForEachFeedback) {
     tokenParameter = [NSString stringWithFormat:@"/%@", [self token]];
   }
   NSMutableString *parameter = [NSMutableString stringWithFormat:@"api/2/apps/%@/feedback%@", [self encodedAppIdentifier], tokenParameter];


### PR DESCRIPTION
This boolean flag disables sending of the token parameter, which forces the backend to create a new thread for each new feedback message.

It's especially useful for use cases where HockeyApp feedback is used by beta testers to report issues and bugs found in the app. Current "single-thread, multiple messages" mode is quite problematic since it makes it hard to track status of various issues being reported by testers.

This feature has been also requested in HockeyApp support forum, e.g. 

- https://support.hockeyapp.net/discussions/problems/28975-single-feedback-thread
- https://support.hockeyapp.net/discussions/problems/55916-how-am-i-supposed-to-start-a-new-feedback-after-another

ping @anlinde 