### PR TITLE
Ensure we present StoreUpdateManager alert on the main thread

### DIFF
--- a/Classes/BITStoreUpdateManager.m
+++ b/Classes/BITStoreUpdateManager.m
@@ -440,6 +440,7 @@
 #pragma mark - Alert
 
 - (void)showUpdateAlert {
+  dispatch_async(dispatch_get_main_queue(), ^{
   if (!_updateAlertShowing) {
     NSString *versionString = [NSString stringWithFormat:@"%@ %@", BITHockeyLocalizedString(@"UpdateVersion"), _newStoreVersion];
     /* We won't use this for now until we have a more robust solution for displaying UIAlertController
@@ -497,6 +498,7 @@
     
     _updateAlertShowing = YES;
   }
+  });
 }
 
 


### PR DESCRIPTION
When the StoreUpdate check [uses `NSURLSession`](https://github.com/bitstadium/HockeySDK-iOS/blob/b7d896afe2436bd5c99a0a2896dbb44a5eaa1970/Classes/BITStoreUpdateManager.m#L361), it doesn't take care to ensure the callback is on the `mainQueue` as [is done in the `NSURLConnection` case](https://github.com/bitstadium/HockeySDK-iOS/blob/b7d896afe2436bd5c99a0a2896dbb44a5eaa1970/Classes/BITStoreUpdateManager.m#L377). This ended up causing my app to crash with the following log output:

> This application is modifying the autolayout engine from a background thread, which can lead to engine corruption and weird crashes.  This will cause an exception in a future release.

An alternative solution would have been to instead initialize the `NSURLSessionConfiguration` using `+sessionWithConfiguration:delegate:delegateQueue:` and passing `[NSOperationQueue mainQueue]`, similar to what is done for the `NSURLConnection` path, but I thought providing the main-thread guarantee at the area where it is actually an issue a more appropriate approach.