### PR TITLE
Add Bitcode marker back to simulator slices

### DIFF
--- a/Support/release.xcconfig
+++ b/Support/release.xcconfig
@@ -1,4 +1,4 @@
 #include "buildnumber.xcconfig"
 
 OTHER_CFLAGS[sdk=iphoneos9.*] = $(HOCKEYSDK_WARNING_FLAGS) -fembed-bitcode
-OTHER_CFLAGS[sdk=iphonesimulator9.*] = $(HOCKEYSDK_WARNING_FLAGS)
+OTHER_CFLAGS[sdk=iphonesimulator9.*] = $(HOCKEYSDK_WARNING_FLAGS) -fembed-bitcode-marker


### PR DESCRIPTION
This is necessary because otherwise `lipo` apparently strips the Bitcode sections from the merged library completely.
Unfortunately, this breaks compatibility with Xcode 6.