### PR TITLE
Switch BITWebTableViewCell baseURL to "about:blank"

### DIFF
--- a/Classes/BITWebTableViewCell.m
+++ b/Classes/BITWebTableViewCell.m
@@ -88,7 +88,7 @@ body { font: 13px 'Helvetica Neue', Helvetica; color:#626262; word-wrap:break-wo
     
     //HockeySDKLog(@"%@\n%@\%@", PSWebTableViewCellHtmlTemplate, deviceWidth, self.webViewContent);
     NSString *contentHtml = [NSString stringWithFormat:BITWebTableViewCellHtmlTemplate, deviceWidth, self.webViewContent];
-    [_webView loadHTMLString:contentHtml baseURL:nil];
+    [_webView loadHTMLString:contentHtml baseURL:[NSURL URLWithString:@"about:blank"]];
   }
 }
 


### PR DESCRIPTION
Hello,

This pull requests makes a very minor change to a UIWebView used in BITWebTableViewCell.

Specifically, HTML data gets loaded in the Webview using a call to ```loadHTMLString:contentHtml baseURL:nil```. This call gets flagged by a security scanner as a nil baseURL has the side-effect of disabling the same-origin policy in the Webview; this is a security issue as it allows the content in the Webview to access every other domain or file. 

In the context of the BITWebTableViewCell, it is not exploitable at all as the content to be displayed is just a small HTML page (the BITWebTableViewCellHtmlTemplate) with no possibility of data injection. However, it is still a best practice to not pass nil as the baseURL, and the page might become more complex or the code might get re-used somewhere else.

Hence, this pull request changes the baseURL to "about:blank", which puts the Webview's content in a very strict origin where it cannot access any other page or file.
