### PR TITLE
Update BITAttributedLabel with changes from TTTAttributedLabel 1.13.4

### DIFF
--- a/Classes/BITAttributedLabel.h
+++ b/Classes/BITAttributedLabel.h
@@ -1,17 +1,17 @@
 // TTTAttributedLabel.h
 //
 // Copyright (c) 2011 Mattt Thompson (http://mattt.me)
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,14 +23,22 @@
 #import <UIKit/UIKit.h>
 #import <CoreText/CoreText.h>
 
+//! Project version number for BITAttributedLabel.
+FOUNDATION_EXPORT double BITAttributedLabelVersionNumber;
+
+//! Project version string for BITAttributedLabel.
+FOUNDATION_EXPORT const unsigned char BITAttributedLabelVersionString[];
+
+@class BITAttributedLabelLink;
+
 /**
  Vertical alignment for text in a label whose bounds are larger than its text bounds
  */
-typedef enum {
-    BITAttributedLabelVerticalAlignmentCenter   = 0,
-    BITAttributedLabelVerticalAlignmentTop      = 1,
-    BITAttributedLabelVerticalAlignmentBottom   = 2,
-} BITAttributedLabelVerticalAlignment;
+typedef NS_ENUM(NSInteger, BITAttributedLabelVerticalAlignment) {
+  BITAttributedLabelVerticalAlignmentCenter   = 0,
+  BITAttributedLabelVerticalAlignmentTop      = 1,
+  BITAttributedLabelVerticalAlignmentBottom   = 2,
+};
 
 /**
  Determines whether the text to which this attribute applies has a strikeout drawn through itself.
@@ -41,6 +49,11 @@ extern NSString * const kBITStrikeOutAttributeName;
  The background fill color. Value must be a `CGColorRef`. Default value is `nil` (no fill).
  */
 extern NSString * const kBITBackgroundFillColorAttributeName;
+
+/**
+ The padding for the background fill. Value must be a `UIEdgeInsets`. Default value is `UIEdgeInsetsZero` (no padding).
+ */
+extern NSString * const kBITBackgroundFillPaddingAttributeName;
 
 /**
  The background stroke color. Value must be a `CGColorRef`. Default value is `nil` (no stroke).
@@ -61,25 +74,43 @@ extern NSString * const kBITBackgroundCornerRadiusAttributeName;
 
 // Override UILabel @property to accept both NSString and NSAttributedString
 @protocol BITAttributedLabel <NSObject>
-@property (nonatomic, copy) id text;
+@property (nonatomic, copy) IBInspectable id text;
 @end
 
+IB_DESIGNABLE
+
 /**
- `TTTAttributedLabel` is a drop-in replacement for `UILabel` that supports `NSAttributedString`, as well as automatically-detected and manually-added links to URLs, addresses, phone numbers, and dates.
+ `BITAttributedLabel` is a drop-in replacement for `UILabel` that supports `NSAttributedString`, as well as automatically-detected and manually-added links to URLs, addresses, phone numbers, and dates.
  
- # Differences Between `TTTAttributedLabel` and `UILabel`
+ ## Differences Between `BITAttributedLabel` and `UILabel`
  
- For the most part, `TTTAttributedLabel` behaves just like `UILabel`. The following are notable exceptions, in which `TTTAttributedLabel` properties may act differently:
+ For the most part, `BITAttributedLabel` behaves just like `UILabel`. The following are notable exceptions, in which `BITAttributedLabel` may act differently:
  
  - `text` - This property now takes an `id` type argument, which can either be a kind of `NSString` or `NSAttributedString` (mutable or immutable in both cases)
+ - `attributedText` - Do not set this property directly. Instead, pass an `NSAttributedString` to `text`.
  - `lineBreakMode` - This property displays only the first line when the value is `UILineBreakModeHeadTruncation`, `UILineBreakModeTailTruncation`, or `UILineBreakModeMiddleTruncation`
  - `adjustsFontsizeToFitWidth` - Supported in iOS 5 and greater, this property is effective for any value of `numberOfLines` greater than zero. In iOS 4, setting `numberOfLines` to a value greater than 1 with `adjustsFontSizeToFitWidth` set to `YES` may cause `sizeToFit` to execute indefinitely.
+ - `baselineAdjustment` - This property has no affect.
+ - `textAlignment` - This property does not support justified alignment.
+ - `NSTextAttachment` - This string attribute is not supported.
  
- Any properties affecting text or paragraph styling, such as `shadowRadius` or `firstLineIndent` will only apply when text is set with an `NSString`. If the text is set with an `NSAttributedString`, these properties will not apply.
+ Any properties affecting text or paragraph styling, such as `firstLineIndent` will only apply when text is set with an `NSString`. If the text is set with an `NSAttributedString`, these properties will not apply.
+ 
+ ### NSCoding
+ 
+ `BITAttributedLabel`, like `UILabel`, conforms to `NSCoding`. However, if the build target is set to less than iOS 6.0, `linkAttributes` and `activeLinkAttributes` will not be encoded or decoded. This is due to an runtime exception thrown when attempting to copy non-object CoreText values in dictionaries.
  
  @warning Any properties changed on the label after setting the text will not be reflected until a subsequent call to `setText:` or `setText:afterInheritingLabelAttributesAndConfiguringWithBlock:`. This is to say, order of operations matters in this case. For example, if the label text color is originally black when the text is set, changing the text color to red will have no effect on the display of the label until the text is set once again.
+ 
+ @bug Setting `attributedText` directly is not recommended, as it may cause a crash when attempting to access any links previously set. Instead, call `setText:`, passing an `NSAttributedString`.
  */
 @interface BITAttributedLabel : UILabel <BITAttributedLabel, UIGestureRecognizerDelegate>
+
+/**
+ * The designated initializers are @c initWithFrame: and @c initWithCoder:.
+ * init will not properly initialize many required properties and other configuration.
+ */
+- (instancetype) init NS_UNAVAILABLE;
 
 ///-----------------------------
 /// @name Accessing the Delegate
@@ -88,20 +119,25 @@ extern NSString * const kBITBackgroundCornerRadiusAttributeName;
 /**
  The receiver's delegate.
  
- @discussion A `TTTAttributedLabel` delegate responds to messages sent by tapping on links in the label. You can use the delegate to respond to links referencing a URL, address, phone number, date, or date with a specified time zone and duration.
+ @discussion A `BITAttributedLabel` delegate responds to messages sent by tapping on links in the label. You can use the delegate to respond to links referencing a URL, address, phone number, date, or date with a specified time zone and duration.
  */
-@property (nonatomic, unsafe_unretained) id <BITAttributedLabelDelegate> delegate;
+@property (nonatomic, unsafe_unretained) IBOutlet id <BITAttributedLabelDelegate> delegate;
 
 ///--------------------------------------------
 /// @name Detecting, Accessing, & Styling Links
 ///--------------------------------------------
 
 /**
- A bitmask of `UIDataDetectorTypes` which are used to automatically detect links in the label text. This is `UIDataDetectorTypeNone` by default.
- 
- @warning You must specify `dataDetectorTypes` before setting the `text`, with either `setText:` or `setText:afterInheritingLabelAttributesAndConfiguringWithBlock:`.
+ @deprecated Use `enabledTextCheckingTypes` property instead.
  */
-@property (nonatomic, assign) UIDataDetectorTypes dataDetectorTypes;
+@property (nonatomic, assign) NSTextCheckingTypes dataDetectorTypes DEPRECATED_ATTRIBUTE;
+
+/**
+ A bitmask of `NSTextCheckingType` which are used to automatically detect links in the label text.
+ 
+ @warning You must specify `enabledTextCheckingTypes` before setting the `text`, with either `setText:` or `setText:afterInheritingLabelAttributesAndConfiguringWithBlock:`.
+ */
+@property (nonatomic, assign) NSTextCheckingTypes enabledTextCheckingTypes;
 
 /**
  An array of `NSTextCheckingResult` objects for links detected or manually added to the label text.
@@ -109,49 +145,99 @@ extern NSString * const kBITBackgroundCornerRadiusAttributeName;
 @property (readonly, nonatomic, strong) NSArray *links;
 
 /**
- A dictionary containing the `NSAttributedString` attributes to be applied to links detected or manually added to the label text. The default link style is blue and underlined.
+ A dictionary containing the default `NSAttributedString` attributes to be applied to links detected or manually added to the label text. The default link style is blue and underlined.
  
- @warning You must specify `linkAttributes` before setting autodetecting or manually-adding links for these attributes to be applied.
+ @warning You must specify `linkAttributes` before setting autodecting or manually-adding links for these attributes to be applied.
  */
 @property (nonatomic, strong) NSDictionary *linkAttributes;
 
 /**
- A dictionary containing the `NSAttributedString` attributes to be applied to links when they are in the active state. Supply `nil` or an empty dictionary to opt out of active link styling. The default active link style is red and underlined.
+ A dictionary containing the default `NSAttributedString` attributes to be applied to links when they are in the active state. If `nil` or an empty `NSDictionary`, active links will not be styled. The default active link style is red and underlined.
  */
 @property (nonatomic, strong) NSDictionary *activeLinkAttributes;
 
+/**
+ A dictionary containing the default `NSAttributedString` attributes to be applied to links when they are in the inactive state, which is triggered by a change in `tintColor` in iOS 7 and later. If `nil` or an empty `NSDictionary`, inactive links will not be styled. The default inactive link style is gray and unadorned.
+ */
+@property (nonatomic, strong) NSDictionary *inactiveLinkAttributes;
+
+/**
+ The edge inset for the background of a link. The default value is `{0, -1, 0, -1}`.
+ */
+@property (nonatomic, assign) UIEdgeInsets linkBackgroundEdgeInset;
+
+/**
+ Indicates if links will be detected within an extended area around the touch
+ to emulate the link detection behaviour of UIWebView.
+ Default value is YES. Disable to to improve performance on long labels.
+ */
+@property (nonatomic, assign) BOOL extendsLinkTouchArea;
+
 ///---------------------------------------
-/// @name Accessing Text Style Attributes
+/// @name Acccessing Text Style Attributes
 ///---------------------------------------
 
 /**
- The shadow blur radius for the label. A value of 0 indicates no blur, while larger values produce correspondingly larger blurring. This value must not be negative. The default value is 0. 
+ The shadow blur radius for the label. A value of 0 indicates no blur, while larger values produce correspondingly larger blurring. This value must not be negative. The default value is 0.
  */
-@property (nonatomic, assign) CGFloat shadowRadius;
+@property (nonatomic, assign) IBInspectable CGFloat shadowRadius;
+
+/**
+ The shadow blur radius for the label when the label's `highlighted` property is `YES`. A value of 0 indicates no blur, while larger values produce correspondingly larger blurring. This value must not be negative. The default value is 0.
+ */
+@property (nonatomic, assign) IBInspectable CGFloat highlightedShadowRadius;
+/**
+ The shadow offset for the label when the label's `highlighted` property is `YES`. A size of {0, 0} indicates no offset, with positive values extending down and to the right. The default size is {0, 0}.
+ */
+@property (nonatomic, assign) IBInspectable CGSize highlightedShadowOffset;
+/**
+ The shadow color for the label when the label's `highlighted` property is `YES`. The default value is `nil` (no shadow color).
+ */
+@property (nonatomic, strong) IBInspectable UIColor *highlightedShadowColor;
+
+/**
+ The amount to kern the next character. Default is standard kerning. If this attribute is set to 0.0, no kerning is done at all.
+ */
+@property (nonatomic, assign) IBInspectable CGFloat kern;
 
 ///--------------------------------------------
-/// @name Accessing Paragraph Style Attributes
+/// @name Acccessing Paragraph Style Attributes
 ///--------------------------------------------
 
 /**
- The distance, in points, from the leading margin of a frame to the beginning of the paragraph's first line. This value is always nonnegative, and is 0.0 by default. 
+ The distance, in points, from the leading margin of a frame to the beginning of the paragraph's first line. This value is always nonnegative, and is 0.0 by default.
  */
-@property (nonatomic, assign) CGFloat firstLineIndent;
+@property (nonatomic, assign) IBInspectable CGFloat firstLineIndent;
 
 /**
- The space in points added between lines within the paragraph. This value is always nonnegative and is 0.0 by default. 
+ @deprecated Use `lineSpacing` instead.
  */
-@property (nonatomic, assign) CGFloat leading;
+@property (nonatomic, assign) IBInspectable CGFloat leading DEPRECATED_ATTRIBUTE;
 
 /**
- The line height multiple. This value is 0.0 by default.
+ The space in points added between lines within the paragraph. This value is always nonnegative and is 0.0 by default.
  */
-@property (nonatomic, assign) CGFloat lineHeightMultiple;
+@property (nonatomic, assign) IBInspectable CGFloat lineSpacing;
+
+/**
+ The minimum line height within the paragraph. If the value is 0.0, the minimum line height is set to the line height of the `font`. 0.0 by default.
+ */
+@property (nonatomic, assign) IBInspectable CGFloat minimumLineHeight;
+
+/**
+ The maximum line height within the paragraph. If the value is 0.0, the maximum line height is set to the line height of the `font`. 0.0 by default.
+ */
+@property (nonatomic, assign) IBInspectable CGFloat maximumLineHeight;
+
+/**
+ The line height multiple. This value is 1.0 by default.
+ */
+@property (nonatomic, assign) IBInspectable CGFloat lineHeightMultiple;
 
 /**
  The distance, in points, from the margin to the text container. This value is `UIEdgeInsetsZero` by default.
  
- @discussion The `UIEdgeInset` members correspond to paragraph style properties rather than a particular geometry, and can change depending on the writing direction. 
+ @discussion The `UIEdgeInset` members correspond to paragraph style properties rather than a particular geometry, and can change depending on the writing direction.
  
  ## `UIEdgeInset` Member Correspondence With `CTParagraphStyleSpecifier` Values:
  
@@ -161,12 +247,57 @@ extern NSString * const kBITBackgroundCornerRadiusAttributeName;
  - `right`: `kCTParagraphStyleSpecifierTailIndent`
  
  */
-@property (nonatomic, assign) UIEdgeInsets textInsets;
+@property (nonatomic, assign) IBInspectable UIEdgeInsets textInsets;
 
 /**
- The vertical text alignment for the label, for when the frame size is greater than the text rect size. The vertical alignment is `TTTAttributedLabelVerticalAlignmentCenter` by default.
+ The vertical text alignment for the label, for when the frame size is greater than the text rect size. The vertical alignment is `BITAttributedLabelVerticalAlignmentCenter` by default.
  */
 @property (nonatomic, assign) BITAttributedLabelVerticalAlignment verticalAlignment;
+
+///--------------------------------------------
+/// @name Accessing Truncation Token Appearance
+///--------------------------------------------
+
+/**
+ @deprecated Use `attributedTruncationToken` instead.
+ */
+@property (nonatomic, strong) NSString *truncationTokenString DEPRECATED_ATTRIBUTE;
+
+/**
+ @deprecated Use `attributedTruncationToken` instead.
+ */
+@property (nonatomic, strong) NSDictionary *truncationTokenStringAttributes DEPRECATED_ATTRIBUTE;
+
+/**
+ The attributed string to apply to the truncation token at the end of a truncated line. Overrides `truncationTokenStringAttributes` and `truncationTokenString`. If unspecified, attributes will fallback to `truncationTokenStringAttributes` and `truncationTokenString`.
+ */
+@property (nonatomic, strong) IBInspectable NSAttributedString *attributedTruncationToken;
+
+///--------------------------
+/// @name Long press gestures
+///--------------------------
+
+/**
+ *  The long-press gesture recognizer used internally by the label.
+ */
+@property (nonatomic, strong, readonly) UILongPressGestureRecognizer *longPressGestureRecognizer;
+
+///--------------------------------------------
+/// @name Calculating Size of Attributed String
+///--------------------------------------------
+
+/**
+ Calculate and return the size that best fits an attributed string, given the specified constraints on size and number of lines.
+ 
+ @param attributedString The attributed string.
+ @param size The maximum dimensions used to calculate size.
+ @param numberOfLines The maximum number of lines in the text to draw, if the constraining size cannot accomodate the full attributed string.
+ 
+ @return The size that fits the attributed string within the specified constraints.
+ */
++ (CGSize)sizeThatFitsAttributedString:(NSAttributedString *)attributedString
+                       withConstraints:(CGSize)size
+                limitedToNumberOfLines:(NSUInteger)numberOfLines;
 
 ///----------------------------------
 /// @name Setting the Text Attributes
@@ -176,7 +307,7 @@ extern NSString * const kBITBackgroundCornerRadiusAttributeName;
  Sets the text displayed by the label.
  
  @param text An `NSString` or `NSAttributedString` object to be displayed by the label. If the specified text is an `NSString`, the label will display the text like a `UILabel`, inheriting the text styles of the label. If the specified text is an `NSAttributedString`, the label text styles will be overridden by the styles specified in the attributed string.
-  
+ 
  @discussion This method overrides `UILabel -setText:` to accept both `NSString` and `NSAttributedString` objects. This string is `nil` by default.
  */
 - (void)setText:(id)text;
@@ -189,14 +320,17 @@ extern NSString * const kBITBackgroundCornerRadiusAttributeName;
  
  @discussion This string is `nil` by default.
  */
-- (void)setText:(id)text afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString *(^)(NSMutableAttributedString *mutableAttributedString))block;
+- (void)setText:(id)text
+afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString *(^)(NSMutableAttributedString *mutableAttributedString))block;
 
-///----------------------------------
+///------------------------------------
 /// @name Accessing the Text Attributes
-///----------------------------------
+///------------------------------------
 
 /**
  A copy of the label's current attributedText. This returns `nil` if an attributed string has never been set on the label.
+ 
+ @warning Do not set this property directly. Instead, set @c text to an @c NSAttributedString.
  */
 @property (readwrite, nonatomic, copy) NSAttributedString *attributedText;
 
@@ -205,27 +339,44 @@ extern NSString * const kBITBackgroundCornerRadiusAttributeName;
 ///-------------------
 
 /**
- Adds a link to an `NSTextCheckingResult`.
+ Adds a link. You can customize an individual link's appearance and accessibility value by creating your own @c BITAttributedLabelLink and passing it to this method. The other methods for adding links will use the label's default attributes.
  
- @param result An `NSTextCheckingResult` representing the link's location and type.
+ @warning Modifying the link's attribute dictionaries must be done before calling this method.
+ 
+ @param link A @c BITAttributedLabelLink object.
  */
-- (void)addLinkWithTextCheckingResult:(NSTextCheckingResult *)result;
+- (void)addLink:(BITAttributedLabelLink *)link;
 
 /**
- Adds a link to an `NSTextCheckingResult`.
+ Adds a link to an @c NSTextCheckingResult.
  
- @param result An `NSTextCheckingResult` representing the link's location and type.
- @param attributes The attributes to be added to the text in the range of the specified link. If `nil`, no attributes are added.
+ @param result An @c NSTextCheckingResult representing the link's location and type.
+ 
+ @return The newly added link object.
  */
-- (void)addLinkWithTextCheckingResult:(NSTextCheckingResult *)result attributes:(NSDictionary *)attributes;
+- (BITAttributedLabelLink *)addLinkWithTextCheckingResult:(NSTextCheckingResult *)result;
+
+/**
+ Adds a link to an @c NSTextCheckingResult.
+ 
+ @param result An @c NSTextCheckingResult representing the link's location and type.
+ @param attributes The attributes to be added to the text in the range of the specified link. If set, the label's @c activeAttributes and @c inactiveAttributes will be applied to the link. If `nil`, no attributes are added to the link.
+ 
+ @return The newly added link object.
+ */
+- (BITAttributedLabelLink *)addLinkWithTextCheckingResult:(NSTextCheckingResult *)result
+                                               attributes:(NSDictionary *)attributes;
 
 /**
  Adds a link to a URL for a specified range in the label text.
  
  @param url The url to be linked to
  @param range The range in the label text of the link. The range must not exceed the bounds of the receiver.
+ 
+ @return The newly added link object.
  */
-- (void)addLinkToURL:(NSURL *)url withRange:(NSRange)range;
+- (BITAttributedLabelLink *)addLinkToURL:(NSURL *)url
+                               withRange:(NSRange)range;
 
 /**
  Adds a link to an address for a specified range in the label text.
@@ -233,25 +384,34 @@ extern NSString * const kBITBackgroundCornerRadiusAttributeName;
  @param addressComponents A dictionary of address components for the address to be linked to
  @param range The range in the label text of the link. The range must not exceed the bounds of the receiver.
  
- @discussion The address component dictionary keys are described in `NSTextCheckingResult`'s "Keys for Address Components." 
+ @discussion The address component dictionary keys are described in `NSTextCheckingResult`'s "Keys for Address Components."
+ 
+ @return The newly added link object.
  */
-- (void)addLinkToAddress:(NSDictionary *)addressComponents withRange:(NSRange)range;
+- (BITAttributedLabelLink *)addLinkToAddress:(NSDictionary *)addressComponents
+                                   withRange:(NSRange)range;
 
 /**
  Adds a link to a phone number for a specified range in the label text.
  
  @param phoneNumber The phone number to be linked to.
  @param range The range in the label text of the link. The range must not exceed the bounds of the receiver.
+ 
+ @return The newly added link object.
  */
-- (void)addLinkToPhoneNumber:(NSString *)phoneNumber withRange:(NSRange)range;
+- (BITAttributedLabelLink *)addLinkToPhoneNumber:(NSString *)phoneNumber
+                                       withRange:(NSRange)range;
 
 /**
  Adds a link to a date for a specified range in the label text.
  
  @param date The date to be linked to.
  @param range The range in the label text of the link. The range must not exceed the bounds of the receiver.
+ 
+ @return The newly added link object.
  */
-- (void)addLinkToDate:(NSDate *)date withRange:(NSRange)range;
+- (BITAttributedLabelLink *)addLinkToDate:(NSDate *)date
+                                withRange:(NSRange)range;
 
 /**
  Adds a link to a date with a particular time zone and duration for a specified range in the label text.
@@ -260,13 +420,38 @@ extern NSString * const kBITBackgroundCornerRadiusAttributeName;
  @param timeZone The time zone of the specified date.
  @param duration The duration, in seconds from the specified date.
  @param range The range in the label text of the link. The range must not exceed the bounds of the receiver.
+ 
+ @return The newly added link object.
  */
-- (void)addLinkToDate:(NSDate *)date timeZone:(NSTimeZone *)timeZone duration:(NSTimeInterval)duration withRange:(NSRange)range;
+- (BITAttributedLabelLink *)addLinkToDate:(NSDate *)date
+                                 timeZone:(NSTimeZone *)timeZone
+                                 duration:(NSTimeInterval)duration
+                                withRange:(NSRange)range;
+
+/**
+ Adds a link to transit information for a specified range in the label text.
+ 
+ @param components A dictionary containing the transit components. The currently supported keys are `NSTextCheckingAirlineKey` and `NSTextCheckingFlightKey`.
+ @param range The range in the label text of the link. The range must not exceed the bounds of the receiver.
+ 
+ @return The newly added link object.
+ */
+- (BITAttributedLabelLink *)addLinkToTransitInformation:(NSDictionary *)components
+                                              withRange:(NSRange)range;
+
+/**
+ Returns whether an @c NSTextCheckingResult is found at the give point.
+ 
+ @discussion This can be used together with @c UITapGestureRecognizer to tap interactions with overlapping views.
+ 
+ @param point The point inside the label.
+ */
+- (BOOL)containslinkAtPoint:(CGPoint)point;
 
 @end
 
 /**
- The `TTTAttributedLabelDelegate` protocol defines the messages sent to an attributed label delegate when links are tapped. All of the methods of this protocol are optional.
+ The `BITAttributedLabelDelegate` protocol defines the messages sent to an attributed label delegate when links are tapped. All of the methods of this protocol are optional.
  */
 @protocol BITAttributedLabelDelegate <NSObject>
 
@@ -281,7 +466,8 @@ extern NSString * const kBITBackgroundCornerRadiusAttributeName;
  @param label The label whose link was selected.
  @param url The URL for the selected link.
  */
-- (void)attributedLabel:(BITAttributedLabel *)label didSelectLinkWithURL:(NSURL *)url;
+- (void)attributedLabel:(BITAttributedLabel *)label
+   didSelectLinkWithURL:(NSURL *)url;
 
 /**
  Tells the delegate that the user did select a link to an address.
@@ -289,7 +475,8 @@ extern NSString * const kBITBackgroundCornerRadiusAttributeName;
  @param label The label whose link was selected.
  @param addressComponents The components of the address for the selected link.
  */
-- (void)attributedLabel:(BITAttributedLabel *)label didSelectLinkWithAddress:(NSDictionary *)addressComponents;
+- (void)attributedLabel:(BITAttributedLabel *)label
+didSelectLinkWithAddress:(NSDictionary *)addressComponents;
 
 /**
  Tells the delegate that the user did select a link to a phone number.
@@ -297,15 +484,17 @@ extern NSString * const kBITBackgroundCornerRadiusAttributeName;
  @param label The label whose link was selected.
  @param phoneNumber The phone number for the selected link.
  */
-- (void)attributedLabel:(BITAttributedLabel *)label didSelectLinkWithPhoneNumber:(NSString *)phoneNumber;
+- (void)attributedLabel:(BITAttributedLabel *)label
+didSelectLinkWithPhoneNumber:(NSString *)phoneNumber;
 
 /**
  Tells the delegate that the user did select a link to a date.
  
  @param label The label whose link was selected.
- @param date The date for the selected link.
+ @param date The datefor the selected link.
  */
-- (void)attributedLabel:(BITAttributedLabel *)label didSelectLinkWithDate:(NSDate *)date;
+- (void)attributedLabel:(BITAttributedLabel *)label
+  didSelectLinkWithDate:(NSDate *)date;
 
 /**
  Tells the delegate that the user did select a link to a date with a time zone and duration.
@@ -315,16 +504,195 @@ extern NSString * const kBITBackgroundCornerRadiusAttributeName;
  @param timeZone The time zone of the date for the selected link.
  @param duration The duration, in seconds from the date for the selected link.
  */
-- (void)attributedLabel:(BITAttributedLabel *)label didSelectLinkWithDate:(NSDate *)date timeZone:(NSTimeZone *)timeZone duration:(NSTimeInterval)duration;
+- (void)attributedLabel:(BITAttributedLabel *)label
+  didSelectLinkWithDate:(NSDate *)date
+               timeZone:(NSTimeZone *)timeZone
+               duration:(NSTimeInterval)duration;
+
+/**
+ Tells the delegate that the user did select a link to transit information
+ 
+ @param label The label whose link was selected.
+ @param components A dictionary containing the transit components. The currently supported keys are `NSTextCheckingAirlineKey` and `NSTextCheckingFlightKey`.
+ */
+- (void)attributedLabel:(BITAttributedLabel *)label
+didSelectLinkWithTransitInformation:(NSDictionary *)components;
 
 /**
  Tells the delegate that the user did select a link to a text checking result.
  
- @discussion This method is called if no other delegate method was called, which can occur by either now implementing the method in `TTTAttributedLabelDelegate` corresponding to a particular link, or the link was added by passing an instance of a custom `NSTextCheckingResult` subclass into `-addLinkWithTextCheckingResult:`.
+ @discussion This method is called if no other delegate method was called, which can occur by either now implementing the method in `BITAttributedLabelDelegate` corresponding to a particular link, or the link was added by passing an instance of a custom `NSTextCheckingResult` subclass into `-addLinkWithTextCheckingResult:`.
  
  @param label The label whose link was selected.
  @param result The custom text checking result.
  */
-- (void)attributedLabel:(BITAttributedLabel *)label didSelectLinkWithTextCheckingResult:(NSTextCheckingResult *)result;
+- (void)attributedLabel:(BITAttributedLabel *)label
+didSelectLinkWithTextCheckingResult:(NSTextCheckingResult *)result;
+
+///---------------------------------
+/// @name Responding to Long Presses
+///---------------------------------
+
+/**
+ *  Long-press delegate methods include the CGPoint tapped within the label's coordinate space.
+ *  This may be useful on iPad to present a popover from a specific origin point.
+ */
+
+/**
+ Tells the delegate that the user long-pressed a link to a URL.
+ 
+ @param label The label whose link was long pressed.
+ @param url The URL for the link.
+ @param point the point pressed, in the label's coordinate space
+ */
+- (void)attributedLabel:(BITAttributedLabel *)label
+didLongPressLinkWithURL:(NSURL *)url
+                atPoint:(CGPoint)point;
+
+/**
+ Tells the delegate that the user long-pressed a link to an address.
+ 
+ @param label The label whose link was long pressed.
+ @param addressComponents The components of the address for the link.
+ @param point the point pressed, in the label's coordinate space
+ */
+- (void)attributedLabel:(BITAttributedLabel *)label
+didLongPressLinkWithAddress:(NSDictionary *)addressComponents
+                atPoint:(CGPoint)point;
+
+/**
+ Tells the delegate that the user long-pressed a link to a phone number.
+ 
+ @param label The label whose link was long pressed.
+ @param phoneNumber The phone number for the link.
+ @param point the point pressed, in the label's coordinate space
+ */
+- (void)attributedLabel:(BITAttributedLabel *)label
+didLongPressLinkWithPhoneNumber:(NSString *)phoneNumber
+                atPoint:(CGPoint)point;
+
+
+/**
+ Tells the delegate that the user long-pressed a link to a date.
+ 
+ @param label The label whose link was long pressed.
+ @param date The date for the selected link.
+ @param point the point pressed, in the label's coordinate space
+ */
+- (void)attributedLabel:(BITAttributedLabel *)label
+didLongPressLinkWithDate:(NSDate *)date
+                atPoint:(CGPoint)point;
+
+
+/**
+ Tells the delegate that the user long-pressed a link to a date with a time zone and duration.
+ 
+ @param label The label whose link was long pressed.
+ @param date The date for the link.
+ @param timeZone The time zone of the date for the link.
+ @param duration The duration, in seconds from the date for the link.
+ @param point the point pressed, in the label's coordinate space
+ */
+- (void)attributedLabel:(BITAttributedLabel *)label
+didLongPressLinkWithDate:(NSDate *)date
+               timeZone:(NSTimeZone *)timeZone
+               duration:(NSTimeInterval)duration
+                atPoint:(CGPoint)point;
+
+
+/**
+ Tells the delegate that the user long-pressed a link to transit information.
+ 
+ @param label The label whose link was long pressed.
+ @param components A dictionary containing the transit components. The currently supported keys are `NSTextCheckingAirlineKey` and `NSTextCheckingFlightKey`.
+ @param point the point pressed, in the label's coordinate space
+ */
+- (void)attributedLabel:(BITAttributedLabel *)label
+didLongPressLinkWithTransitInformation:(NSDictionary *)components
+                atPoint:(CGPoint)point;
+
+/**
+ Tells the delegate that the user long-pressed a link to a text checking result.
+ 
+ @discussion Similar to `-attributedLabel:didSelectLinkWithTextCheckingResult:`, this method is called if a link is long pressed and the delegate does not implement the method corresponding to this type of link.
+ 
+ @param label The label whose link was long pressed.
+ @param result The custom text checking result.
+ @param point the point pressed, in the label's coordinate space
+ */
+- (void)attributedLabel:(BITAttributedLabel *)label
+didLongPressLinkWithTextCheckingResult:(NSTextCheckingResult *)result
+                atPoint:(CGPoint)point;
+
+@end
+
+@interface BITAttributedLabelLink : NSObject <NSCoding>
+
+typedef void (^BITAttributedLabelLinkBlock) (BITAttributedLabel *, BITAttributedLabelLink *);
+
+/**
+ An `NSTextCheckingResult` representing the link's location and type.
+ */
+@property (readonly, nonatomic, strong) NSTextCheckingResult *result;
+
+/**
+ A dictionary containing the @c NSAttributedString attributes to be applied to the link.
+ */
+@property (readonly, nonatomic, copy) NSDictionary *attributes;
+
+/**
+ A dictionary containing the @c NSAttributedString attributes to be applied to the link when it is in the active state.
+ */
+@property (readonly, nonatomic, copy) NSDictionary *activeAttributes;
+
+/**
+ A dictionary containing the @c NSAttributedString attributes to be applied to the link when it is in the inactive state, which is triggered by a change in `tintColor` in iOS 7 and later.
+ */
+@property (readonly, nonatomic, copy) NSDictionary *inactiveAttributes;
+
+/**
+ Additional information about a link for VoiceOver users. Has default values if the link's @c result is @c NSTextCheckingTypeLink, @c NSTextCheckingTypePhoneNumber, or @c NSTextCheckingTypeDate.
+ */
+@property (nonatomic, copy) NSString *accessibilityValue;
+
+/**
+ A block called when this link is tapped.
+ If non-nil, tapping on this link will call this block instead of the
+ @c BITAttributedLabelDelegate tap methods, which will not be called for this link.
+ */
+@property (nonatomic, copy) BITAttributedLabelLinkBlock linkTapBlock;
+
+/**
+ A block called when this link is long-pressed.
+ If non-nil, long pressing on this link will call this block instead of the
+ @c BITAttributedLabelDelegate long press methods, which will not be called for this link.
+ */
+@property (nonatomic, copy) BITAttributedLabelLinkBlock linkLongPressBlock;
+
+/**
+ Initializes a link using the attribute dictionaries specified.
+ 
+ @param attributes         The @c attributes property for the link.
+ @param activeAttributes   The @c activeAttributes property for the link.
+ @param inactiveAttributes The @c inactiveAttributes property for the link.
+ @param result             An @c NSTextCheckingResult representing the link's location and type.
+ 
+ @return The initialized link object.
+ */
+- (instancetype)initWithAttributes:(NSDictionary *)attributes
+                  activeAttributes:(NSDictionary *)activeAttributes
+                inactiveAttributes:(NSDictionary *)inactiveAttributes
+                textCheckingResult:(NSTextCheckingResult *)result;
+
+/**
+ Initializes a link using the attribute dictionaries set on a specified label.
+ 
+ @param label  The attributed label from which to inherit attribute dictionaries.
+ @param result An @c NSTextCheckingResult representing the link's location and type.
+ 
+ @return The initialized link object.
+ */
+- (instancetype)initWithAttributesFromLabel:(BITAttributedLabel*)label
+                         textCheckingResult:(NSTextCheckingResult *)result;
 
 @end

--- a/Classes/BITAttributedLabel.m
+++ b/Classes/BITAttributedLabel.m
@@ -26,48 +26,79 @@
 
 #import "BITAttributedLabel.h"
 
+#import <QuartzCore/QuartzCore.h>
+#import <Availability.h>
+#import <objc/runtime.h>
+
 #define kBITLineBreakWordWrapTextWidthScalingFactor (M_PI / M_E)
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 
+static CGFloat const BITFLOAT_MAX = 100000;
+
 NSString * const kBITStrikeOutAttributeName = @"BITStrikeOutAttribute";
 NSString * const kBITBackgroundFillColorAttributeName = @"BITBackgroundFillColor";
+NSString * const kBITBackgroundFillPaddingAttributeName = @"BITBackgroundFillPadding";
 NSString * const kBITBackgroundStrokeColorAttributeName = @"BITBackgroundStrokeColor";
 NSString * const kBITBackgroundLineWidthAttributeName = @"BITBackgroundLineWidth";
 NSString * const kBITBackgroundCornerRadiusAttributeName = @"BITBackgroundCornerRadius";
 
-static inline __attribute__((unused)) CTTextAlignment CTTextAlignmentFromUITextAlignment(UITextAlignment alignment) {
-    switch (alignment) {
-        case UITextAlignmentLeft: return kCTLeftTextAlignment;
-        case UITextAlignmentCenter: return kCTCenterTextAlignment;
-        case UITextAlignmentRight: return kCTRightTextAlignment;
-        default: return kCTNaturalTextAlignment;
-    }
-}
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 60000
+const NSTextAlignment BITTextAlignmentLeft = NSTextAlignmentLeft;
+const NSTextAlignment BITTextAlignmentCenter = NSTextAlignmentCenter;
+const NSTextAlignment BITTextAlignmentRight = NSTextAlignmentRight;
+const NSTextAlignment BITTextAlignmentJustified = NSTextAlignmentJustified;
+const NSTextAlignment BITTextAlignmentNatural = NSTextAlignmentNatural;
 
-static __attribute__((unused)) inline CTTextAlignment CTTextAlignmentFromNSTextAlignment(NSTextAlignment alignment) {
+const NSLineBreakMode BITLineBreakByWordWrapping = NSLineBreakByWordWrapping;
+const NSLineBreakMode BITLineBreakByCharWrapping = NSLineBreakByCharWrapping;
+const NSLineBreakMode BITLineBreakByClipping = NSLineBreakByClipping;
+const NSLineBreakMode BITLineBreakByTruncatingHead = NSLineBreakByTruncatingHead;
+const NSLineBreakMode BITLineBreakByTruncatingMiddle = NSLineBreakByTruncatingMiddle;
+const NSLineBreakMode BITLineBreakByTruncatingTail = NSLineBreakByTruncatingTail;
+
+typedef NSTextAlignment BITTextAlignment;
+typedef NSLineBreakMode BITLineBreakMode;
+#else
+const UITextAlignment BITTextAlignmentLeft = NSTextAlignmentLeft;
+const UITextAlignment BITTextAlignmentCenter = NSTextAlignmentCenter;
+const UITextAlignment BITTextAlignmentRight = NSTextAlignmentRight;
+const UITextAlignment BITTextAlignmentJustified = NSTextAlignmentJustified;
+const UITextAlignment BITTextAlignmentNatural = NSTextAlignmentNatural;
+
+const UITextAlignment BITLineBreakByWordWrapping = NSLineBreakByWordWrapping;
+const UITextAlignment BITLineBreakByCharWrapping = NSLineBreakByCharWrapping;
+const UITextAlignment BITLineBreakByClipping = NSLineBreakByClipping;
+const UITextAlignment BITLineBreakByTruncatingHead = NSLineBreakByTruncatingHead;
+const UITextAlignment BITLineBreakByTruncatingMiddle = NSLineBreakByTruncatingMiddle;
+const UITextAlignment BITLineBreakByTruncatingTail = NSLineBreakByTruncatingTail;
+
+typedef UITextAlignment BITTextAlignment;
+typedef UILineBreakMode BITLineBreakMode;
+#endif
+
+
+static inline CTTextAlignment CTTextAlignmentFromBITTextAlignment(BITTextAlignment alignment) {
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 60000
     switch (alignment) {
         case NSTextAlignmentLeft: return kCTLeftTextAlignment;
         case NSTextAlignmentCenter: return kCTCenterTextAlignment;
         case NSTextAlignmentRight: return kCTRightTextAlignment;
         default: return kCTNaturalTextAlignment;
     }
-}
-
-static inline CTLineBreakMode CTLineBreakModeFromUILineBreakMode(UILineBreakMode lineBreakMode) {
-    switch (lineBreakMode) {
-        case UILineBreakModeWordWrap: return kCTLineBreakByWordWrapping;
-        case UILineBreakModeCharacterWrap: return kCTLineBreakByCharWrapping;
-        case UILineBreakModeClip: return kCTLineBreakByClipping;
-        case UILineBreakModeHeadTruncation: return kCTLineBreakByTruncatingHead;
-        case UILineBreakModeTailTruncation: return kCTLineBreakByTruncatingTail;
-        case UILineBreakModeMiddleTruncation: return kCTLineBreakByTruncatingMiddle;
-        default: return 0;
+#else
+    switch (alignment) {
+        case UITextAlignmentLeft: return kCTLeftTextAlignment;
+        case UITextAlignmentCenter: return kCTCenterTextAlignment;
+        case UITextAlignmentRight: return kCTRightTextAlignment;
+        default: return kCTNaturalTextAlignment;
     }
+#endif
 }
 
-static inline __attribute__((unused)) CTLineBreakMode CTLineBreakModeFromNSLineBreakMode(NSLineBreakMode lineBreakMode) {
+static inline CTLineBreakMode CTLineBreakModeFromBITLineBreakMode(BITLineBreakMode lineBreakMode) {
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 60000
     switch (lineBreakMode) {
         case NSLineBreakByWordWrapping: return kCTLineBreakByWordWrapping;
         case NSLineBreakByCharWrapping: return kCTLineBreakByCharWrapping;
@@ -77,104 +108,157 @@ static inline __attribute__((unused)) CTLineBreakMode CTLineBreakModeFromNSLineB
         case NSLineBreakByTruncatingMiddle: return kCTLineBreakByTruncatingMiddle;
         default: return 0;
     }
+#else
+    return CTLineBreakModeFromUILineBreakMode(lineBreakMode);
+#endif
 }
 
-static inline __attribute__((unused)) UILineBreakMode UILineBreakModeFromNSLineBreakMode(NSLineBreakMode lineBreakMode) {
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < 60000
+static inline CTLineBreakMode CTLineBreakModeFromUILineBreakMode(UILineBreakMode lineBreakMode) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     switch (lineBreakMode) {
-        case NSLineBreakByWordWrapping: return UILineBreakModeWordWrap;
-        case NSLineBreakByCharWrapping: return UILineBreakModeCharacterWrap;
-        case NSLineBreakByClipping: return UILineBreakModeClip;
-        case NSLineBreakByTruncatingHead: return UILineBreakModeHeadTruncation;
-        case NSLineBreakByTruncatingTail: return UILineBreakModeTailTruncation;
-        case NSLineBreakByTruncatingMiddle: return UILineBreakModeMiddleTruncation;
+        case UILineBreakModeWordWrap: return kCTLineBreakByWordWrapping;
+        case UILineBreakModeCharacterWrap: return kCTLineBreakByCharWrapping;
+        case UILineBreakModeClip: return kCTLineBreakByClipping;
+        case UILineBreakModeHeadTruncation: return kCTLineBreakByTruncatingHead;
+        case UILineBreakModeTailTruncation: return kCTLineBreakByTruncatingTail;
+        case UILineBreakModeMiddleTruncation: return kCTLineBreakByTruncatingMiddle;
         default: return 0;
     }
+#pragma clang diagnostic pop
+}
+#endif
+
+static inline CGFLOAT_TYPE CGFloat_ceil(CGFLOAT_TYPE cgfloat) {
+#if CGFLOAT_IS_DOUBLE
+    return ceil(cgfloat);
+#else
+    return ceilf(cgfloat);
+#endif
 }
 
-static inline NSTextCheckingType NSTextCheckingTypeFromUIDataDetectorType(UIDataDetectorTypes dataDetectorType) {
-    NSTextCheckingType textCheckingType = 0;
-    if (dataDetectorType & UIDataDetectorTypeAddress) {
-        textCheckingType |= NSTextCheckingTypeAddress;
+static inline CGFLOAT_TYPE CGFloat_floor(CGFLOAT_TYPE cgfloat) {
+#if CGFLOAT_IS_DOUBLE
+    return floor(cgfloat);
+#else
+    return floorf(cgfloat);
+#endif
+}
+
+static inline CGFLOAT_TYPE CGFloat_round(CGFLOAT_TYPE cgfloat) {
+#if CGFLOAT_IS_DOUBLE
+    return round(cgfloat);
+#else
+    return roundf(cgfloat);
+#endif
+}
+
+static inline CGFLOAT_TYPE CGFloat_sqrt(CGFLOAT_TYPE cgfloat) {
+#if CGFLOAT_IS_DOUBLE
+    return sqrt(cgfloat);
+#else
+    return sqrtf(cgfloat);
+#endif
+}
+
+static inline CGFloat BITFlushFactorForTextAlignment(NSTextAlignment textAlignment) {
+    switch (textAlignment) {
+        case BITTextAlignmentCenter:
+            return 0.5f;
+        case BITTextAlignmentRight:
+            return 1.0f;
+        case BITTextAlignmentLeft:
+        default:
+            return 0.0f;
     }
-    
-    if (dataDetectorType & UIDataDetectorTypeCalendarEvent) {
-        textCheckingType |= NSTextCheckingTypeDate;
-    }
-    
-    if (dataDetectorType & UIDataDetectorTypeLink) {
-        textCheckingType |= NSTextCheckingTypeLink;
-    }
-    
-    if (dataDetectorType & UIDataDetectorTypePhoneNumber) {
-        textCheckingType |= NSTextCheckingTypePhoneNumber;
-    }
-    
-    return textCheckingType;
 }
 
 static inline NSDictionary * NSAttributedStringAttributesFromLabel(BITAttributedLabel *label) {
-    NSMutableDictionary *mutableAttributes = [NSMutableDictionary dictionary]; 
+    NSMutableDictionary *mutableAttributes = [NSMutableDictionary dictionary];
     
-    CTFontRef font = CTFontCreateWithName((__bridge CFStringRef)label.font.fontName, label.font.pointSize, NULL);
-    [mutableAttributes setObject:(__bridge id)font forKey:(NSString *)kCTFontAttributeName];
-    CFRelease(font);
-    
-    [mutableAttributes setObject:(id)[label.textColor CGColor] forKey:(NSString *)kCTForegroundColorAttributeName];
-    
-#ifdef __IPHONE_6_0
-    CTTextAlignment alignment = CTTextAlignmentFromNSTextAlignment(label.textAlignment);
-#else
-    CTTextAlignment alignment = CTTextAlignmentFromUITextAlignment(label.textAlignment);
-#endif
-    CGFloat lineSpacing = label.leading;
-    CGFloat lineSpacingAdjustment = label.font.lineHeight - label.font.ascender + label.font.descender;
-    CGFloat lineHeightMultiple = label.lineHeightMultiple;
-    CGFloat topMargin = label.textInsets.top;
-    CGFloat bottomMargin = label.textInsets.bottom;
-    CGFloat leftMargin = label.textInsets.left;
-    CGFloat rightMargin = label.textInsets.right;
-    CGFloat firstLineIndent = label.firstLineIndent + leftMargin;
-
-    CTLineBreakMode lineBreakMode;
-    if (label.numberOfLines != 1) {
-        lineBreakMode = CTLineBreakModeFromUILineBreakMode(UILineBreakModeWordWrap);
+    if ([NSMutableParagraphStyle class]) {
+        [mutableAttributes setObject:label.font forKey:(NSString *)kCTFontAttributeName];
+        [mutableAttributes setObject:label.textColor forKey:(NSString *)kCTForegroundColorAttributeName];
+        [mutableAttributes setObject:@(label.kern) forKey:(NSString *)kCTKernAttributeName];
+        
+        NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
+        paragraphStyle.alignment = label.textAlignment;
+        paragraphStyle.lineSpacing = label.lineSpacing;
+        paragraphStyle.minimumLineHeight = label.minimumLineHeight > 0 ? label.minimumLineHeight : label.font.lineHeight * label.lineHeightMultiple;
+        paragraphStyle.maximumLineHeight = label.maximumLineHeight > 0 ? label.maximumLineHeight : label.font.lineHeight * label.lineHeightMultiple;
+        paragraphStyle.lineHeightMultiple = label.lineHeightMultiple;
+        paragraphStyle.firstLineHeadIndent = label.firstLineIndent;
+        
+        if (label.numberOfLines == 1) {
+            paragraphStyle.lineBreakMode = label.lineBreakMode;
+        } else {
+            paragraphStyle.lineBreakMode = NSLineBreakByWordWrapping;
+        }
+        
+        [mutableAttributes setObject:paragraphStyle forKey:(NSString *)kCTParagraphStyleAttributeName];
     } else {
-#ifdef __IPHONE_6_0
-        lineBreakMode = CTLineBreakModeFromNSLineBreakMode(label.lineBreakMode);
-#else
-        lineBreakMode = CTLineBreakModeFromUILineBreakMode(label.lineBreakMode);
-#endif
+        CTFontRef font = CTFontCreateWithName((__bridge CFStringRef)label.font.fontName, label.font.pointSize, NULL);
+        [mutableAttributes setObject:(__bridge id)font forKey:(NSString *)kCTFontAttributeName];
+        CFRelease(font);
+        
+        [mutableAttributes setObject:(id)[label.textColor CGColor] forKey:(NSString *)kCTForegroundColorAttributeName];
+        [mutableAttributes setObject:@(label.kern) forKey:(NSString *)kCTKernAttributeName];
+        
+        CTTextAlignment alignment = CTTextAlignmentFromBITTextAlignment(label.textAlignment);
+        CGFloat lineSpacing = label.lineSpacing;
+        CGFloat minimumLineHeight = label.minimumLineHeight * label.lineHeightMultiple;
+        CGFloat maximumLineHeight = label.maximumLineHeight * label.lineHeightMultiple;
+        CGFloat lineSpacingAdjustment = CGFloat_ceil(label.font.lineHeight - label.font.ascender + label.font.descender);
+        CGFloat lineHeightMultiple = label.lineHeightMultiple;
+        CGFloat firstLineIndent = label.firstLineIndent;
+        
+        CTLineBreakMode lineBreakMode = kCTLineBreakByWordWrapping;
+        if (label.numberOfLines == 1) {
+            lineBreakMode = CTLineBreakModeFromBITLineBreakMode(label.lineBreakMode);
+        }
+        
+        CTParagraphStyleSetting paragraphStyles[12] = {
+            {.spec = kCTParagraphStyleSpecifierAlignment, .valueSize = sizeof(CTTextAlignment), .value = (const void *)&alignment},
+            {.spec = kCTParagraphStyleSpecifierLineBreakMode, .valueSize = sizeof(CTLineBreakMode), .value = (const void *)&lineBreakMode},
+            {.spec = kCTParagraphStyleSpecifierLineSpacing, .valueSize = sizeof(CGFloat), .value = (const void *)&lineSpacing},
+            {.spec = kCTParagraphStyleSpecifierMinimumLineSpacing, .valueSize = sizeof(CGFloat), .value = (const void *)&minimumLineHeight},
+            {.spec = kCTParagraphStyleSpecifierMaximumLineSpacing, .valueSize = sizeof(CGFloat), .value = (const void *)&maximumLineHeight},
+            {.spec = kCTParagraphStyleSpecifierLineSpacingAdjustment, .valueSize = sizeof (CGFloat), .value = (const void *)&lineSpacingAdjustment},
+            {.spec = kCTParagraphStyleSpecifierLineHeightMultiple, .valueSize = sizeof(CGFloat), .value = (const void *)&lineHeightMultiple},
+            {.spec = kCTParagraphStyleSpecifierFirstLineHeadIndent, .valueSize = sizeof(CGFloat), .value = (const void *)&firstLineIndent},
+        };
+        
+        CTParagraphStyleRef paragraphStyle = CTParagraphStyleCreate(paragraphStyles, 12);
+        
+        [mutableAttributes setObject:(__bridge id)paragraphStyle forKey:(NSString *)kCTParagraphStyleAttributeName];
+        
+        CFRelease(paragraphStyle);
     }
-	
-    CTParagraphStyleSetting paragraphStyles[10] = {
-		{.spec = kCTParagraphStyleSpecifierAlignment, .valueSize = sizeof(CTTextAlignment), .value = (const void *)&alignment},
-		{.spec = kCTParagraphStyleSpecifierLineBreakMode, .valueSize = sizeof(CTLineBreakMode), .value = (const void *)&lineBreakMode},
-        {.spec = kCTParagraphStyleSpecifierLineSpacing, .valueSize = sizeof(CGFloat), .value = (const void *)&lineSpacing},
-        {.spec = kCTParagraphStyleSpecifierLineSpacingAdjustment, .valueSize = sizeof (CGFloat), .value = (const void *)&lineSpacingAdjustment},
-        {.spec = kCTParagraphStyleSpecifierLineHeightMultiple, .valueSize = sizeof(CGFloat), .value = (const void *)&lineHeightMultiple},
-        {.spec = kCTParagraphStyleSpecifierFirstLineHeadIndent, .valueSize = sizeof(CGFloat), .value = (const void *)&firstLineIndent},
-        {.spec = kCTParagraphStyleSpecifierParagraphSpacingBefore, .valueSize = sizeof(CGFloat), .value = (const void *)&topMargin},
-        {.spec = kCTParagraphStyleSpecifierParagraphSpacing, .valueSize = sizeof(CGFloat), .value = (const void *)&bottomMargin},
-        {.spec = kCTParagraphStyleSpecifierHeadIndent, .valueSize = sizeof(CGFloat), .value = (const void *)&leftMargin},
-        {.spec = kCTParagraphStyleSpecifierTailIndent, .valueSize = sizeof(CGFloat), .value = (const void *)&rightMargin}
-	};
-
-    CTParagraphStyleRef paragraphStyle = CTParagraphStyleCreate(paragraphStyles, 10);
-	[mutableAttributes setObject:(__bridge id)paragraphStyle forKey:(NSString *)kCTParagraphStyleAttributeName];
-	CFRelease(paragraphStyle);
     
     return [NSDictionary dictionaryWithDictionary:mutableAttributes];
 }
 
-static inline NSAttributedString * NSAttributedStringByScalingFontSize(NSAttributedString *attributedString, CGFloat scale, CGFloat minimumFontSize) {    
+static inline NSAttributedString * NSAttributedStringByScalingFontSize(NSAttributedString *attributedString, CGFloat scale) {
     NSMutableAttributedString *mutableAttributedString = [attributedString mutableCopy];
-    [mutableAttributedString enumerateAttribute:(NSString *)kCTFontAttributeName inRange:NSMakeRange(0, [mutableAttributedString length]) options:0 usingBlock:^(id value, NSRange range, BOOL *stop) {
-        CTFontRef font = (__bridge CTFontRef)value;
+    [mutableAttributedString enumerateAttribute:(NSString *)kCTFontAttributeName inRange:NSMakeRange(0, [mutableAttributedString length]) options:0 usingBlock:^(id value, NSRange range, BOOL * __unused stop) {
+        UIFont *font = (UIFont *)value;
         if (font) {
-            CGFloat scaledFontSize = floorf(CTFontGetSize(font) * scale);
-            CTFontRef scaledFont = CTFontCreateCopyWithAttributes(font, fmaxf(scaledFontSize, minimumFontSize), NULL, NULL);
-            CFAttributedStringSetAttribute((__bridge CFMutableAttributedStringRef)mutableAttributedString, CFRangeMake(range.location, range.length), kCTFontAttributeName, scaledFont);
-            CFRelease(scaledFont);
+            NSString *fontName;
+            CGFloat pointSize;
+            
+            if ([font isKindOfClass:[UIFont class]]) {
+                fontName = font.fontName;
+                pointSize = font.pointSize;
+            } else {
+                fontName = (NSString *)CFBridgingRelease(CTFontCopyName((__bridge CTFontRef)font, kCTFontPostScriptNameKey));
+                pointSize = CTFontGetSize((__bridge CTFontRef)font);
+            }
+            
+            [mutableAttributedString removeAttribute:(NSString *)kCTFontAttributeName range:range];
+            CTFontRef fontRef = CTFontCreateWithName((__bridge CFStringRef)fontName, CGFloat_floor(pointSize * scale), NULL);
+            [mutableAttributedString addAttribute:(NSString *)kCTFontAttributeName value:(__bridge id)fontRef range:range];
+            CFRelease(fontRef);
         }
     }];
     
@@ -186,63 +270,101 @@ static inline NSAttributedString * NSAttributedStringBySettingColorFromContext(N
         return attributedString;
     }
     
-    CGColorRef colorRef = color.CGColor;
-    NSMutableAttributedString *mutableAttributedString = [attributedString mutableCopy];    
-    [mutableAttributedString enumerateAttribute:(NSString *)kCTForegroundColorFromContextAttributeName inRange:NSMakeRange(0, [mutableAttributedString length]) options:0 usingBlock:^(id value, NSRange range, BOOL *stop) {
-        CFBooleanRef usesColorFromContext = (__bridge CFBooleanRef)value;
-        if (usesColorFromContext && CFBooleanGetValue(usesColorFromContext)) {
-            CFRange updateRange = CFRangeMake(range.location, range.length);
-            CFAttributedStringSetAttribute((__bridge CFMutableAttributedStringRef)mutableAttributedString, updateRange, kCTForegroundColorAttributeName, colorRef);
-            CFAttributedStringRemoveAttribute((__bridge CFMutableAttributedStringRef)mutableAttributedString, updateRange, kCTForegroundColorFromContextAttributeName);
+    NSMutableAttributedString *mutableAttributedString = [attributedString mutableCopy];
+    [mutableAttributedString enumerateAttribute:(NSString *)kCTForegroundColorFromContextAttributeName inRange:NSMakeRange(0, [mutableAttributedString length]) options:0 usingBlock:^(id value, NSRange range, __unused BOOL *stop) {
+        BOOL usesColorFromContext = (BOOL)value;
+        if (usesColorFromContext) {
+            [mutableAttributedString setAttributes:[NSDictionary dictionaryWithObject:color forKey:(NSString *)kCTForegroundColorAttributeName] range:range];
+            [mutableAttributedString removeAttribute:(NSString *)kCTForegroundColorFromContextAttributeName range:range];
         }
     }];
     
-    return mutableAttributedString;    
+    return mutableAttributedString;
+}
+
+static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstraints(CTFramesetterRef framesetter, NSAttributedString *attributedString, CGSize size, NSUInteger numberOfLines) {
+    CFRange rangeToSize = CFRangeMake(0, (CFIndex)[attributedString length]);
+    CGSize constraints = CGSizeMake(size.width, BITFLOAT_MAX);
+    
+    if (numberOfLines == 1) {
+        // If there is one line, the size that fits is the full width of the line
+        constraints = CGSizeMake(BITFLOAT_MAX, BITFLOAT_MAX);
+    } else if (numberOfLines > 0) {
+        // If the line count of the label more than 1, limit the range to size to the number of lines that have been set
+        CGMutablePathRef path = CGPathCreateMutable();
+        CGPathAddRect(path, NULL, CGRectMake(0.0f, 0.0f, constraints.width, BITFLOAT_MAX));
+        CTFrameRef frame = CTFramesetterCreateFrame(framesetter, CFRangeMake(0, 0), path, NULL);
+        CFArrayRef lines = CTFrameGetLines(frame);
+        
+        if (CFArrayGetCount(lines) > 0) {
+            NSInteger lastVisibleLineIndex = MIN((CFIndex)numberOfLines, CFArrayGetCount(lines)) - 1;
+            CTLineRef lastVisibleLine = CFArrayGetValueAtIndex(lines, lastVisibleLineIndex);
+            
+            CFRange rangeToLayout = CTLineGetStringRange(lastVisibleLine);
+            rangeToSize = CFRangeMake(0, rangeToLayout.location + rangeToLayout.length);
+        }
+        
+        CFRelease(frame);
+        CFRelease(path);
+    }
+    
+    CGSize suggestedSize = CTFramesetterSuggestFrameSizeWithConstraints(framesetter, rangeToSize, NULL, constraints, NULL);
+    
+    return CGSizeMake(CGFloat_ceil(suggestedSize.width), CGFloat_ceil(suggestedSize.height));
 }
 
 @interface BITAttributedLabel ()
 @property (readwrite, nonatomic, copy) NSAttributedString *inactiveAttributedText;
 @property (readwrite, nonatomic, copy) NSAttributedString *renderedAttributedText;
-@property (readwrite, nonatomic, assign) CTFramesetterRef framesetter;
-@property (readwrite, nonatomic, assign) CTFramesetterRef highlightFramesetter;
-@property (readwrite, nonatomic, strong) NSDataDetector *dataDetector;
-@property (readwrite, nonatomic, strong) NSArray *links;
-@property (readwrite, nonatomic, strong) NSTextCheckingResult *activeLink;
+@property (readwrite, atomic, strong) NSDataDetector *dataDetector;
+@property (readwrite, nonatomic, strong) NSArray *linkModels;
+@property (readwrite, nonatomic, strong) BITAttributedLabelLink *activeLink;
+@property (readwrite, nonatomic, strong) NSArray *accessibilityElements;
 
-- (void)commonInit;
-- (void)setNeedsFramesetter;
-- (NSArray *)detectedLinksInString:(NSString *)string range:(NSRange)range error:(NSError **)error;
-- (NSTextCheckingResult *)linkAtCharacterIndex:(CFIndex)idx;
-- (NSTextCheckingResult *)linkAtPoint:(CGPoint)p;
-- (CFIndex)characterIndexAtPoint:(CGPoint)p;
-- (void)drawFramesetter:(CTFramesetterRef)framesetter attributedString:(NSAttributedString *)attributedString textRange:(CFRange)textRange inRect:(CGRect)rect context:(CGContextRef)c;
-- (void)drawStrike:(CTFrameRef)frame inRect:(CGRect)rect context:(CGContextRef)c;
+- (void) longPressGestureDidFire:(UILongPressGestureRecognizer *)sender;
 @end
 
 @implementation BITAttributedLabel {
 @private
     BOOL _needsFramesetter;
+    CTFramesetterRef _framesetter;
+    CTFramesetterRef _highlightFramesetter;
 }
 
 @dynamic text;
 @synthesize attributedText = _attributedText;
-@synthesize inactiveAttributedText = _inactiveAttributedText;
-@synthesize renderedAttributedText = _renderedAttributedText;
-@synthesize framesetter = _framesetter;
-@synthesize highlightFramesetter = _highlightFramesetter;
-@synthesize delegate = _delegate;
-@synthesize dataDetectorTypes = _dataDetectorTypes;
-@synthesize dataDetector = _dataDetector;
-@synthesize links = _links;
-@synthesize linkAttributes = _linkAttributes;
-@synthesize activeLinkAttributes = _activeLinkAttributes;
-@synthesize shadowRadius = _shadowRadius;
-@synthesize leading = _leading;
-@synthesize lineHeightMultiple = _lineHeightMultiple;
-@synthesize firstLineIndent = _firstLineIndent;
-@synthesize textInsets = _textInsets;
-@synthesize verticalAlignment = _verticalAlignment;
-@synthesize activeLink = _activeLink;
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000
+
+#ifndef kCFCoreFoundationVersionNumber_iOS_7_0
+#define kCFCoreFoundationVersionNumber_iOS_7_0 847.2
+#endif
+
++ (void)load {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        if (kCFCoreFoundationVersionNumber < kCFCoreFoundationVersionNumber_iOS_7_0) {
+            Class class = [self class];
+            Class superclass = class_getSuperclass(class);
+            
+            NSArray *strings = @[
+                                 NSStringFromSelector(@selector(isAccessibilityElement)),
+                                 NSStringFromSelector(@selector(accessibilityElementCount)),
+                                 NSStringFromSelector(@selector(accessibilityElementAtIndex:)),
+                                 NSStringFromSelector(@selector(indexOfAccessibilityElement:)),
+                                 ];
+            
+            for (NSString *string in strings) {
+                SEL selector = NSSelectorFromString(string);
+                IMP superImplementation = class_getMethodImplementation(superclass, selector);
+                Method method = class_getInstanceMethod(class, selector);
+                const char *types = method_getTypeEncoding(method);
+                class_replaceMethod(class, selector, superImplementation, types);
+            }
+        }
+    });
+}
+#endif
 
 - (instancetype)initWithFrame:(CGRect)frame {
     self = [super initWithFrame:frame];
@@ -255,41 +377,77 @@ static inline NSAttributedString * NSAttributedStringBySettingColorFromContext(N
     return self;
 }
 
-- (instancetype)initWithCoder:(NSCoder *)coder {
-    self = [super initWithCoder:coder];
-    if (!self) {
-        return nil;
-    }
-    
-    [self commonInit];
-    
-    return self;
-}
-
 - (void)commonInit {
-    self.dataDetectorTypes = UIDataDetectorTypeNone;
-    self.links = [NSArray array];
-    
-    NSMutableDictionary *mutableLinkAttributes = [NSMutableDictionary dictionary];
-    [mutableLinkAttributes setValue:(id)[[UIColor blueColor] CGColor] forKey:(NSString*)kCTForegroundColorAttributeName];
-    [mutableLinkAttributes setValue:[NSNumber numberWithBool:YES] forKey:(NSString *)kCTUnderlineStyleAttributeName];
-    self.linkAttributes = [NSDictionary dictionaryWithDictionary:mutableLinkAttributes];
-    
-    NSMutableDictionary *mutableActiveLinkAttributes = [NSMutableDictionary dictionary];
-    [mutableActiveLinkAttributes setValue:(id)[[UIColor redColor] CGColor] forKey:(NSString*)kCTForegroundColorAttributeName];
-    [mutableActiveLinkAttributes setValue:[NSNumber numberWithBool:NO] forKey:(NSString *)kCTUnderlineStyleAttributeName];
-
-    self.activeLinkAttributes = [NSDictionary dictionaryWithDictionary:mutableActiveLinkAttributes];
-    
-    self.textInsets = UIEdgeInsetsZero;
-    
     self.userInteractionEnabled = YES;
     self.multipleTouchEnabled = NO;
+    
+    self.textInsets = UIEdgeInsetsZero;
+    self.lineHeightMultiple = 1.0f;
+    
+    self.linkModels = [NSArray array];
+    
+    self.linkBackgroundEdgeInset = UIEdgeInsetsMake(0.0f, -1.0f, 0.0f, -1.0f);
+    
+    NSMutableDictionary *mutableLinkAttributes = [NSMutableDictionary dictionary];
+    [mutableLinkAttributes setObject:[NSNumber numberWithBool:YES] forKey:(NSString *)kCTUnderlineStyleAttributeName];
+    
+    NSMutableDictionary *mutableActiveLinkAttributes = [NSMutableDictionary dictionary];
+    [mutableActiveLinkAttributes setObject:[NSNumber numberWithBool:NO] forKey:(NSString *)kCTUnderlineStyleAttributeName];
+    
+    NSMutableDictionary *mutableInactiveLinkAttributes = [NSMutableDictionary dictionary];
+    [mutableInactiveLinkAttributes setObject:[NSNumber numberWithBool:NO] forKey:(NSString *)kCTUnderlineStyleAttributeName];
+    
+    if ([NSMutableParagraphStyle class]) {
+        [mutableLinkAttributes setObject:[UIColor blueColor] forKey:(NSString *)kCTForegroundColorAttributeName];
+        [mutableActiveLinkAttributes setObject:[UIColor redColor] forKey:(NSString *)kCTForegroundColorAttributeName];
+        [mutableInactiveLinkAttributes setObject:[UIColor grayColor] forKey:(NSString *)kCTForegroundColorAttributeName];
+    } else {
+        [mutableLinkAttributes setObject:(__bridge id)[[UIColor blueColor] CGColor] forKey:(NSString *)kCTForegroundColorAttributeName];
+        [mutableActiveLinkAttributes setObject:(__bridge id)[[UIColor redColor] CGColor] forKey:(NSString *)kCTForegroundColorAttributeName];
+        [mutableInactiveLinkAttributes setObject:(__bridge id)[[UIColor grayColor] CGColor] forKey:(NSString *)kCTForegroundColorAttributeName];
+    }
+    
+    self.linkAttributes = [NSDictionary dictionaryWithDictionary:mutableLinkAttributes];
+    self.activeLinkAttributes = [NSDictionary dictionaryWithDictionary:mutableActiveLinkAttributes];
+    self.inactiveLinkAttributes = [NSDictionary dictionaryWithDictionary:mutableInactiveLinkAttributes];
+    _extendsLinkTouchArea = YES;
+    _longPressGestureRecognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self
+                                                                                action:@selector(longPressGestureDidFire:)];
+    self.longPressGestureRecognizer.delegate = self;
+    [self addGestureRecognizer:self.longPressGestureRecognizer];
 }
 
 - (void)dealloc {
-    if (_framesetter) CFRelease(_framesetter);
-    if (_highlightFramesetter) CFRelease(_highlightFramesetter);
+    if (_framesetter) {
+        CFRelease(_framesetter);
+    }
+    
+    if (_highlightFramesetter) {
+        CFRelease(_highlightFramesetter);
+    }
+    
+    if (_longPressGestureRecognizer) {
+        [self removeGestureRecognizer:_longPressGestureRecognizer];
+    }
+}
+
+#pragma mark -
+
++ (CGSize)sizeThatFitsAttributedString:(NSAttributedString *)attributedString
+                       withConstraints:(CGSize)size
+                limitedToNumberOfLines:(NSUInteger)numberOfLines
+{
+    if (!attributedString || attributedString.length == 0) {
+        return CGSizeZero;
+    }
+    
+    CTFramesetterRef framesetter = CTFramesetterCreateWithAttributedString((__bridge CFAttributedStringRef)attributedString);
+    
+    CGSize calculatedSize = CTFramesetterSuggestFrameSizeForAttributedStringWithConstraints(framesetter, attributedString, size, numberOfLines);
+    
+    CFRelease(framesetter);
+    
+    return calculatedSize;
 }
 
 #pragma mark -
@@ -299,38 +457,18 @@ static inline NSAttributedString * NSAttributedStringBySettingColorFromContext(N
         return;
     }
     
-    [self willChangeValueForKey:@"attributedText"];
     _attributedText = [text copy];
-    [self didChangeValueForKey:@"attributedText"];
     
     [self setNeedsFramesetter];
-}
-
-- (void)setNeedsFramesetter {
-    // Reset the rendered attributed text so it has a chance to regenerate
-    self.renderedAttributedText = nil;
-
-    _needsFramesetter = YES;
-}
-
-- (CTFramesetterRef)framesetter {
-    if (_needsFramesetter) {
-        @synchronized(self) {
-            if (_framesetter) {
-              CFRelease(_framesetter);
-              _framesetter = nil;
-            }
-            if (_highlightFramesetter) {
-              CFRelease(_highlightFramesetter);
-              _highlightFramesetter = nil;
-            }
-            
-            _framesetter = CTFramesetterCreateWithAttributedString((__bridge CFAttributedStringRef)self.renderedAttributedText);
-            _needsFramesetter = NO;
-        }
-    }
+    [self setNeedsDisplay];
     
-    return _framesetter;
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 60000
+    if ([self respondsToSelector:@selector(invalidateIntrinsicContentSize)]) {
+        [self invalidateIntrinsicContentSize];
+    }
+#endif
+    
+    [super setText:[self.attributedText string]];
 }
 
 - (NSAttributedString *)renderedAttributedText {
@@ -341,101 +479,254 @@ static inline NSAttributedString * NSAttributedStringBySettingColorFromContext(N
     return _renderedAttributedText;
 }
 
-#pragma mark -
+- (NSArray *) links {
+    return [_linkModels valueForKey:@"result"];
+}
 
-- (void)setLinkActive:(BOOL)active withTextCheckingResult:(NSTextCheckingResult *)result {
-    if (result && [self.activeLinkAttributes count] > 0) {
-        if (active) {
-            if (!self.inactiveAttributedText) {
-                self.inactiveAttributedText = self.attributedText;
-            }
+- (void)setLinkModels:(NSArray *)linkModels {
+    _linkModels = linkModels;
+    
+    self.accessibilityElements = nil;
+}
+
+- (void)setNeedsFramesetter {
+    // Reset the rendered attributed text so it has a chance to regenerate
+    self.renderedAttributedText = nil;
+    
+    _needsFramesetter = YES;
+}
+
+- (CTFramesetterRef)framesetter {
+    if (_needsFramesetter) {
+        @synchronized(self) {
+            CTFramesetterRef framesetter = CTFramesetterCreateWithAttributedString((__bridge CFAttributedStringRef)self.renderedAttributedText);
+            [self setFramesetter:framesetter];
+            [self setHighlightFramesetter:nil];
+            _needsFramesetter = NO;
             
-            NSMutableAttributedString *mutableAttributedString = [self.inactiveAttributedText mutableCopy];
-            [mutableAttributedString addAttributes:self.activeLinkAttributes range:result.range];
-            self.attributedText = mutableAttributedString;
-            
-            [self setNeedsDisplay];
-        } else {
-            if (self.inactiveAttributedText) {
-                self.attributedText = self.inactiveAttributedText;
-                self.inactiveAttributedText = nil;
-                
-                [self setNeedsDisplay];
+            if (framesetter) {
+                CFRelease(framesetter);
             }
         }
     }
+    
+    return _framesetter;
+}
+
+- (void)setFramesetter:(CTFramesetterRef)framesetter {
+    if (framesetter) {
+        CFRetain(framesetter);
+    }
+    
+    if (_framesetter) {
+        CFRelease(_framesetter);
+    }
+    
+    _framesetter = framesetter;
+}
+
+- (CTFramesetterRef)highlightFramesetter {
+    return _highlightFramesetter;
+}
+
+- (void)setHighlightFramesetter:(CTFramesetterRef)highlightFramesetter {
+    if (highlightFramesetter) {
+        CFRetain(highlightFramesetter);
+    }
+    
+    if (_highlightFramesetter) {
+        CFRelease(_highlightFramesetter);
+    }
+    
+    _highlightFramesetter = highlightFramesetter;
+}
+
+- (CGFloat)leading {
+    return self.lineSpacing;
+}
+
+- (void)setLeading:(CGFloat)leading {
+    self.lineSpacing = leading;
 }
 
 #pragma mark -
 
-- (void)setDataDetectorTypes:(UIDataDetectorTypes)dataDetectorTypes {
-    [self willChangeValueForKey:@"dataDetectorTypes"];
-    _dataDetectorTypes = dataDetectorTypes;
-    [self didChangeValueForKey:@"dataDetectorTypes"];
+- (NSTextCheckingTypes)dataDetectorTypes {
+    return self.enabledTextCheckingTypes;
+}
+
+- (void)setDataDetectorTypes:(NSTextCheckingTypes)dataDetectorTypes {
+    self.enabledTextCheckingTypes = dataDetectorTypes;
+}
+
+- (void)setEnabledTextCheckingTypes:(NSTextCheckingTypes)enabledTextCheckingTypes {
+    if (self.enabledTextCheckingTypes == enabledTextCheckingTypes) {
+        return;
+    }
     
-    if (self.dataDetectorTypes != UIDataDetectorTypeNone) {
-        self.dataDetector = [NSDataDetector dataDetectorWithTypes:NSTextCheckingTypeFromUIDataDetectorType(self.dataDetectorTypes) error:nil];
+    _enabledTextCheckingTypes = enabledTextCheckingTypes;
+    
+    if (self.enabledTextCheckingTypes) {
+        self.dataDetector = [NSDataDetector dataDetectorWithTypes:self.enabledTextCheckingTypes error:nil];
+    } else {
+        self.dataDetector = nil;
     }
 }
 
-- (NSArray *)detectedLinksInString:(NSString *)string range:(NSRange)range error:(NSError **)error {
-    if (!string || !self.dataDetector) {
-        return [NSArray array];
+- (void)addLink:(BITAttributedLabelLink *)link {
+    [self addLinks:@[link]];
+}
+
+- (void)addLinks:(NSArray *)links {
+    NSMutableArray *mutableLinkModels = [NSMutableArray arrayWithArray:self.linkModels];
+    
+    NSMutableAttributedString *mutableAttributedString = [self.attributedText mutableCopy];
+    
+    for (BITAttributedLabelLink *link in links) {
+        if (link.attributes) {
+            [mutableAttributedString addAttributes:link.attributes range:link.result.range];
+        }
     }
     
-    return [self.dataDetector matchesInString:string options:0 range:range];
-}
-
-- (void)addLinkWithTextCheckingResult:(NSTextCheckingResult *)result attributes:(NSDictionary *)attributes {
-    self.links = [self.links arrayByAddingObject:result];
+    self.attributedText = mutableAttributedString;
+    [self setNeedsDisplay];
     
-    if (attributes) {
-        NSMutableAttributedString *mutableAttributedString = [[NSMutableAttributedString alloc] initWithAttributedString:self.attributedText];
-        [mutableAttributedString addAttributes:attributes range:result.range];
-        self.attributedText = mutableAttributedString;        
+    [mutableLinkModels addObjectsFromArray:links];
+    
+    self.linkModels = [NSArray arrayWithArray:mutableLinkModels];
+}
+
+- (BITAttributedLabelLink *)addLinkWithTextCheckingResult:(NSTextCheckingResult *)result
+                                               attributes:(NSDictionary *)attributes
+{
+    return [self addLinksWithTextCheckingResults:@[result] attributes:attributes].firstObject;
+}
+
+- (NSArray *)addLinksWithTextCheckingResults:(NSArray *)results
+                                  attributes:(NSDictionary *)attributes
+{
+    NSMutableArray *links = [NSMutableArray array];
+    
+    for (NSTextCheckingResult *result in results) {
+        NSDictionary *activeAttributes = attributes ? self.activeLinkAttributes : nil;
+        NSDictionary *inactiveAttributes = attributes ? self.inactiveLinkAttributes : nil;
+        
+        BITAttributedLabelLink *link = [[BITAttributedLabelLink alloc] initWithAttributes:attributes
+                                                                         activeAttributes:activeAttributes
+                                                                       inactiveAttributes:inactiveAttributes
+                                                                       textCheckingResult:result];
+        
+        [links addObject:link];
     }
+    
+    [self addLinks:links];
+    
+    return links;
 }
 
-- (void)addLinkWithTextCheckingResult:(NSTextCheckingResult *)result {
-    [self addLinkWithTextCheckingResult:result attributes:self.linkAttributes];
+- (BITAttributedLabelLink *)addLinkWithTextCheckingResult:(NSTextCheckingResult *)result {
+    return [self addLinkWithTextCheckingResult:result attributes:self.linkAttributes];
 }
 
-- (void)addLinkToURL:(NSURL *)url withRange:(NSRange)range {
-    [self addLinkWithTextCheckingResult:[NSTextCheckingResult linkCheckingResultWithRange:range URL:url]];
+- (BITAttributedLabelLink *)addLinkToURL:(NSURL *)url
+                               withRange:(NSRange)range
+{
+    return [self addLinkWithTextCheckingResult:[NSTextCheckingResult linkCheckingResultWithRange:range URL:url]];
 }
 
-- (void)addLinkToAddress:(NSDictionary *)addressComponents withRange:(NSRange)range {
-    [self addLinkWithTextCheckingResult:[NSTextCheckingResult addressCheckingResultWithRange:range components:addressComponents]];
+- (BITAttributedLabelLink *)addLinkToAddress:(NSDictionary *)addressComponents
+                                   withRange:(NSRange)range
+{
+    return [self addLinkWithTextCheckingResult:[NSTextCheckingResult addressCheckingResultWithRange:range components:addressComponents]];
 }
 
-- (void)addLinkToPhoneNumber:(NSString *)phoneNumber withRange:(NSRange)range {
-    [self addLinkWithTextCheckingResult:[NSTextCheckingResult phoneNumberCheckingResultWithRange:range phoneNumber:phoneNumber]];
+- (BITAttributedLabelLink *)addLinkToPhoneNumber:(NSString *)phoneNumber
+                                       withRange:(NSRange)range
+{
+    return [self addLinkWithTextCheckingResult:[NSTextCheckingResult phoneNumberCheckingResultWithRange:range phoneNumber:phoneNumber]];
 }
 
-- (void)addLinkToDate:(NSDate *)date withRange:(NSRange)range {
-    [self addLinkWithTextCheckingResult:[NSTextCheckingResult dateCheckingResultWithRange:range date:date]];
+- (BITAttributedLabelLink *)addLinkToDate:(NSDate *)date
+                                withRange:(NSRange)range
+{
+    return [self addLinkWithTextCheckingResult:[NSTextCheckingResult dateCheckingResultWithRange:range date:date]];
 }
 
-- (void)addLinkToDate:(NSDate *)date timeZone:(NSTimeZone *)timeZone duration:(NSTimeInterval)duration withRange:(NSRange)range {
-    [self addLinkWithTextCheckingResult:[NSTextCheckingResult dateCheckingResultWithRange:range date:date timeZone:timeZone duration:duration]];
+- (BITAttributedLabelLink *)addLinkToDate:(NSDate *)date
+                                 timeZone:(NSTimeZone *)timeZone
+                                 duration:(NSTimeInterval)duration
+                                withRange:(NSRange)range
+{
+    return [self addLinkWithTextCheckingResult:[NSTextCheckingResult dateCheckingResultWithRange:range date:date timeZone:timeZone duration:duration]];
+}
+
+- (BITAttributedLabelLink *)addLinkToTransitInformation:(NSDictionary *)components
+                                              withRange:(NSRange)range
+{
+    return [self addLinkWithTextCheckingResult:[NSTextCheckingResult transitInformationCheckingResultWithRange:range components:components]];
 }
 
 #pragma mark -
 
-- (NSTextCheckingResult *)linkAtCharacterIndex:(CFIndex)idx {
-    for (NSTextCheckingResult *result in self.links) {
-        NSRange range = result.range;
-        if ((CFIndex)range.location <= idx && idx <= (CFIndex)(range.location + range.length - 1)) {
-            return result;
+- (BOOL)containslinkAtPoint:(CGPoint)point {
+    return [self linkAtPoint:point] != nil;
+}
+
+- (BITAttributedLabelLink *)linkAtPoint:(CGPoint)point {
+    
+    // Stop quickly if none of the points to be tested are in the bounds.
+    if (!CGRectContainsPoint(CGRectInset(self.bounds, -15.f, -15.f), point) || self.links.count == 0) {
+        return nil;
+    }
+    
+    BITAttributedLabelLink *result = [self linkAtCharacterIndex:[self characterIndexAtPoint:point]];
+    
+    if (!result && self.extendsLinkTouchArea) {
+        result = [self linkAtRadius:2.5f aroundPoint:point]
+        ?: [self linkAtRadius:5.f aroundPoint:point]
+        ?: [self linkAtRadius:7.5f aroundPoint:point]
+        ?: [self linkAtRadius:12.5f aroundPoint:point]
+        ?: [self linkAtRadius:15.f aroundPoint:point];
+    }
+    
+    return result;
+}
+
+- (BITAttributedLabelLink *)linkAtRadius:(const CGFloat)radius aroundPoint:(CGPoint)point {
+    const CGFloat diagonal = CGFloat_sqrt(2 * radius * radius);
+    const CGPoint deltas[] = {
+        CGPointMake(0, -radius), CGPointMake(0, radius), // Above and below
+        CGPointMake(-radius, 0), CGPointMake(radius, 0), // Beside
+        CGPointMake(-diagonal, -diagonal), CGPointMake(-diagonal, diagonal),
+        CGPointMake(diagonal, diagonal), CGPointMake(diagonal, -diagonal) // Diagonal
+    };
+    const size_t count = sizeof(deltas) / sizeof(CGPoint);
+    
+    BITAttributedLabelLink *link = nil;
+    
+    for (NSInteger i = 0; i < count && link.result == nil; i ++) {
+        CGPoint currentPoint = CGPointMake(point.x + deltas[i].x, point.y + deltas[i].y);
+        link = [self linkAtCharacterIndex:[self characterIndexAtPoint:currentPoint]];
+    }
+    
+    return link;
+}
+
+- (BITAttributedLabelLink *)linkAtCharacterIndex:(CFIndex)idx {
+    // Do not enumerate if the index is outside of the bounds of the text.
+    if (!NSLocationInRange((NSUInteger)idx, NSMakeRange(0, self.attributedText.length))) {
+        return nil;
+    }
+    
+    NSEnumerator *enumerator = [self.linkModels reverseObjectEnumerator];
+    BITAttributedLabelLink *link = nil;
+    while ((link = [enumerator nextObject])) {
+        if (NSLocationInRange((NSUInteger)idx, link.result.range)) {
+            return link;
         }
     }
     
     return nil;
-}
-
-- (NSTextCheckingResult *)linkAtPoint:(CGPoint)p {
-    CFIndex idx = [self characterIndexAtPoint:p];
-    return [self linkAtCharacterIndex:idx];
 }
 
 - (CFIndex)characterIndexAtPoint:(CGPoint)p {
@@ -452,15 +743,15 @@ static inline NSAttributedString * NSAttributedStringBySettingColorFromContext(N
     p = CGPointMake(p.x - textRect.origin.x, p.y - textRect.origin.y);
     // Convert tap coordinates (start at top left) to CT coordinates (start at bottom left)
     p = CGPointMake(p.x, textRect.size.height - p.y);
-
+    
     CGMutablePathRef path = CGPathCreateMutable();
     CGPathAddRect(path, NULL, textRect);
-    CTFrameRef frame = CTFramesetterCreateFrame(self.framesetter, CFRangeMake(0, [self.attributedText length]), path, NULL);
+    CTFrameRef frame = CTFramesetterCreateFrame([self framesetter], CFRangeMake(0, (CFIndex)[self.attributedText length]), path, NULL);
     if (frame == NULL) {
         CFRelease(path);
         return NSNotFound;
     }
-
+    
     CFArrayRef lines = CTFrameGetLines(frame);
     NSInteger numberOfLines = self.numberOfLines > 0 ? MIN(self.numberOfLines, CFArrayGetCount(lines)) : CFArrayGetCount(lines);
     if (numberOfLines == 0) {
@@ -469,20 +760,25 @@ static inline NSAttributedString * NSAttributedStringBySettingColorFromContext(N
         return NSNotFound;
     }
     
-    NSUInteger idx = NSNotFound;
-
+    CFIndex idx = NSNotFound;
+    
     CGPoint lineOrigins[numberOfLines];
     CTFrameGetLineOrigins(frame, CFRangeMake(0, numberOfLines), lineOrigins);
-
+    
     for (CFIndex lineIndex = 0; lineIndex < numberOfLines; lineIndex++) {
         CGPoint lineOrigin = lineOrigins[lineIndex];
         CTLineRef line = CFArrayGetValueAtIndex(lines, lineIndex);
         
         // Get bounding information of line
-        CGFloat ascent, descent, leading, width;
-        width = CTLineGetTypographicBounds(line, &ascent, &descent, &leading);
-        CGFloat yMin = floor(lineOrigin.y - descent);
-        CGFloat yMax = ceil(lineOrigin.y + ascent);
+        CGFloat ascent = 0.0f, descent = 0.0f, leading = 0.0f;
+        CGFloat width = (CGFloat)CTLineGetTypographicBounds(line, &ascent, &descent, &leading);
+        CGFloat yMin = (CGFloat)floor(lineOrigin.y - descent);
+        CGFloat yMax = (CGFloat)ceil(lineOrigin.y + ascent);
+        
+        // Apply penOffset using flushFactor for horizontal alignment to set lineOrigin since this is the horizontal offset from drawFramesetter
+        CGFloat flushFactor = BITFlushFactorForTextAlignment(self.textAlignment);
+        CGFloat penOffset = (CGFloat)CTLineGetPenOffsetForFlush(line, flushFactor, textRect.size.width);
+        lineOrigin.x = penOffset;
         
         // Check if we've already passed the line
         if (p.y > yMax) {
@@ -502,28 +798,58 @@ static inline NSAttributedString * NSAttributedStringBySettingColorFromContext(N
     
     CFRelease(frame);
     CFRelease(path);
-        
+    
     return idx;
 }
 
-- (void)drawFramesetter:(CTFramesetterRef)framesetter attributedString:(NSAttributedString *)attributedString textRange:(CFRange)textRange inRect:(CGRect)rect context:(CGContextRef)c {
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000
+- (CGRect)boundingRectForCharacterRange:(NSRange)range {
+    NSMutableAttributedString *mutableAttributedString = [self.attributedText mutableCopy];
+    
+    NSTextStorage *textStorage = [[NSTextStorage alloc] initWithAttributedString:mutableAttributedString];
+    
+    NSLayoutManager *layoutManager = [[NSLayoutManager alloc] init];
+    [textStorage addLayoutManager:layoutManager];
+    
+    NSTextContainer *textContainer = [[NSTextContainer alloc] initWithSize:self.bounds.size];
+    [layoutManager addTextContainer:textContainer];
+    
+    NSRange glyphRange;
+    [layoutManager characterRangeForGlyphRange:range actualGlyphRange:&glyphRange];
+    
+    return [layoutManager boundingRectForGlyphRange:glyphRange inTextContainer:textContainer];
+}
+#endif
+
+- (void)drawFramesetter:(CTFramesetterRef)framesetter
+       attributedString:(NSAttributedString *)attributedString
+              textRange:(CFRange)textRange
+                 inRect:(CGRect)rect
+                context:(CGContextRef)c
+{
     CGMutablePathRef path = CGPathCreateMutable();
     CGPathAddRect(path, NULL, rect);
-    CTFrameRef frame = CTFramesetterCreateFrame(framesetter, textRange, path, NULL);    
+    CTFrameRef frame = CTFramesetterCreateFrame(framesetter, textRange, path, NULL);
     
     [self drawBackground:frame inRect:rect context:c];
     
     CFArrayRef lines = CTFrameGetLines(frame);
     NSInteger numberOfLines = self.numberOfLines > 0 ? MIN(self.numberOfLines, CFArrayGetCount(lines)) : CFArrayGetCount(lines);
-    BOOL truncateLastLine = (self.lineBreakMode == UILineBreakModeHeadTruncation || self.lineBreakMode == UILineBreakModeMiddleTruncation || self.lineBreakMode == UILineBreakModeTailTruncation);
-	
+    BOOL truncateLastLine = (self.lineBreakMode == BITLineBreakByTruncatingHead || self.lineBreakMode == BITLineBreakByTruncatingMiddle || self.lineBreakMode == BITLineBreakByTruncatingTail);
+    
     CGPoint lineOrigins[numberOfLines];
     CTFrameGetLineOrigins(frame, CFRangeMake(0, numberOfLines), lineOrigins);
-        
+    
     for (CFIndex lineIndex = 0; lineIndex < numberOfLines; lineIndex++) {
         CGPoint lineOrigin = lineOrigins[lineIndex];
         CGContextSetTextPosition(c, lineOrigin.x, lineOrigin.y);
         CTLineRef line = CFArrayGetValueAtIndex(lines, lineIndex);
+        
+        CGFloat descent = 0.0f;
+        CTLineGetTypographicBounds((CTLineRef)line, NULL, &descent, NULL);
+        
+        // Adjust pen offset for flush depending on text alignment
+        CGFloat flushFactor = BITFlushFactorForTextAlignment(self.textAlignment);
         
         if (lineIndex == numberOfLines - 1 && truncateLastLine) {
             // Check if the range of text in the last line reaches the end of the full attributed string
@@ -532,53 +858,66 @@ static inline NSAttributedString * NSAttributedStringBySettingColorFromContext(N
             if (!(lastLineRange.length == 0 && lastLineRange.location == 0) && lastLineRange.location + lastLineRange.length < textRange.location + textRange.length) {
                 // Get correct truncationType and attribute position
                 CTLineTruncationType truncationType;
-                NSUInteger truncationAttributePosition = lastLineRange.location;
-#ifdef __IPHONE_6_0
-                UILineBreakMode lineBreakMode = UILineBreakModeFromNSLineBreakMode(self.lineBreakMode);
-#else
-                UILineBreakMode lineBreakMode = self.lineBreakMode;
-#endif
+                CFIndex truncationAttributePosition = lastLineRange.location;
+                BITLineBreakMode lineBreakMode = self.lineBreakMode;
                 
                 // Multiple lines, only use UILineBreakModeTailTruncation
                 if (numberOfLines != 1) {
-                    lineBreakMode = UILineBreakModeTailTruncation;
+                    lineBreakMode = BITLineBreakByTruncatingTail;
                 }
                 
                 switch (lineBreakMode) {
-                    case UILineBreakModeHeadTruncation:
+                    case BITLineBreakByTruncatingHead:
                         truncationType = kCTLineTruncationStart;
                         break;
-                    case UILineBreakModeMiddleTruncation:
+                    case BITLineBreakByTruncatingMiddle:
                         truncationType = kCTLineTruncationMiddle;
                         truncationAttributePosition += (lastLineRange.length / 2);
                         break;
-                    case UILineBreakModeTailTruncation:
+                    case BITLineBreakByTruncatingTail:
                     default:
                         truncationType = kCTLineTruncationEnd;
                         truncationAttributePosition += (lastLineRange.length - 1);
                         break;
                 }
                 
-                // Get the attributes and use them to create the truncation token string
-                NSDictionary *tokenAttributes = [attributedString attributesAtIndex:truncationAttributePosition effectiveRange:NULL];
-                // \u2026 is the Unicode horizontal ellipsis character code
-                NSAttributedString *tokenString = [[NSAttributedString alloc] initWithString:@"\u2026" attributes:tokenAttributes];
-                CTLineRef truncationToken = CTLineCreateWithAttributedString((__bridge CFAttributedStringRef)tokenString);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+                NSAttributedString *attributedTruncationString = self.attributedTruncationToken;
+                if (!attributedTruncationString) {
+                    NSString *truncationTokenString = self.truncationTokenString;
+                    if (!truncationTokenString) {
+                        truncationTokenString = @"\u2026"; // Unicode Character 'HORIZONTAL ELLIPSIS' (U+2026)
+                    }
+                    
+                    NSDictionary *truncationTokenStringAttributes = self.truncationTokenStringAttributes;
+                    if (!truncationTokenStringAttributes) {
+                        truncationTokenStringAttributes = [attributedString attributesAtIndex:(NSUInteger)truncationAttributePosition effectiveRange:NULL];
+                    }
+                    
+                    attributedTruncationString = [[NSAttributedString alloc] initWithString:truncationTokenString attributes:truncationTokenStringAttributes];
+                }
+                CTLineRef truncationToken = CTLineCreateWithAttributedString((__bridge CFAttributedStringRef)attributedTruncationString);
+#pragma clang diagnostic pop
                 
                 // Append truncationToken to the string
-                // because if string isn't too long, CT wont add the truncationToken on it's own
-                // There is no change of a double truncationToken because CT only add the token if it removes characters (and the one we add will go first)
-                NSMutableAttributedString *truncationString = [[attributedString attributedSubstringFromRange:NSMakeRange(lastLineRange.location, lastLineRange.length)] mutableCopy];
+                // because if string isn't too long, CT won't add the truncationToken on its own.
+                // There is no chance of a double truncationToken because CT only adds the
+                // token if it removes characters (and the one we add will go first)
+                NSMutableAttributedString *truncationString = [[NSMutableAttributedString alloc] initWithAttributedString:
+                                                               [attributedString attributedSubstringFromRange:
+                                                                NSMakeRange((NSUInteger)lastLineRange.location,
+                                                                            (NSUInteger)lastLineRange.length)]];
                 if (lastLineRange.length > 0) {
                     // Remove any newline at the end (we don't want newline space between the text and the truncation token). There can only be one, because the second would be on the next line.
-                    unichar lastCharacter = [[truncationString string] characterAtIndex:lastLineRange.length - 1];
+                    unichar lastCharacter = [[truncationString string] characterAtIndex:(NSUInteger)(lastLineRange.length - 1)];
                     if ([[NSCharacterSet newlineCharacterSet] characterIsMember:lastCharacter]) {
-                        [truncationString deleteCharactersInRange:NSMakeRange(lastLineRange.length - 1, 1)];
+                        [truncationString deleteCharactersInRange:NSMakeRange((NSUInteger)(lastLineRange.length - 1), 1)];
                     }
                 }
-                [truncationString appendAttributedString:tokenString];
+                [truncationString appendAttributedString:attributedTruncationString];
                 CTLineRef truncationLine = CTLineCreateWithAttributedString((__bridge CFAttributedStringRef)truncationString);
-
+                
                 // Truncate the line in case it is too long.
                 CTLineRef truncatedLine = CTLineCreateTruncatedLine(truncationLine, rect.size.width, truncationType, truncationToken);
                 if (!truncatedLine) {
@@ -586,63 +925,90 @@ static inline NSAttributedString * NSAttributedStringBySettingColorFromContext(N
                     truncatedLine = CFRetain(truncationToken);
                 }
                 
+                CGFloat penOffset = (CGFloat)CTLineGetPenOffsetForFlush(truncatedLine, flushFactor, rect.size.width);
+                CGContextSetTextPosition(c, penOffset, lineOrigin.y - descent - self.font.descender);
+                
                 CTLineDraw(truncatedLine, c);
+                
+                NSRange linkRange;
+                if ([attributedTruncationString attribute:NSLinkAttributeName atIndex:0 effectiveRange:&linkRange]) {
+                    NSRange tokenRange = [truncationString.string rangeOfString:attributedTruncationString.string];
+                    NSRange tokenLinkRange = NSMakeRange((NSUInteger)(lastLineRange.location+lastLineRange.length)-tokenRange.length, (NSUInteger)tokenRange.length);
+                    
+                    [self addLinkToURL:[attributedTruncationString attribute:NSLinkAttributeName atIndex:0 effectiveRange:&linkRange] withRange:tokenLinkRange];
+                }
                 
                 CFRelease(truncatedLine);
                 CFRelease(truncationLine);
                 CFRelease(truncationToken);
             } else {
+                CGFloat penOffset = (CGFloat)CTLineGetPenOffsetForFlush(line, flushFactor, rect.size.width);
+                CGContextSetTextPosition(c, penOffset, lineOrigin.y - descent - self.font.descender);
                 CTLineDraw(line, c);
             }
         } else {
+            CGFloat penOffset = (CGFloat)CTLineGetPenOffsetForFlush(line, flushFactor, rect.size.width);
+            CGContextSetTextPosition(c, penOffset, lineOrigin.y - descent - self.font.descender);
             CTLineDraw(line, c);
         }
     }
     
     [self drawStrike:frame inRect:rect context:c];
-        
+    
     CFRelease(frame);
-    CFRelease(path);    
+    CFRelease(path);
 }
 
-- (void)drawBackground:(CTFrameRef)frame inRect:(CGRect)rect context:(CGContextRef)c {
+- (void)drawBackground:(CTFrameRef)frame
+                inRect:(CGRect)rect
+               context:(CGContextRef)c
+{
     NSArray *lines = (__bridge NSArray *)CTFrameGetLines(frame);
     CGPoint origins[[lines count]];
     CTFrameGetLineOrigins(frame, CFRangeMake(0, 0), origins);
     
     CFIndex lineIndex = 0;
     for (id line in lines) {
-        CGRect lineBounds = CTLineGetImageBounds((__bridge CTLineRef)line, c);
-        lineBounds.origin.x = origins[lineIndex].x;
-        lineBounds.origin.y = origins[lineIndex].y;
+        CGFloat ascent = 0.0f, descent = 0.0f, leading = 0.0f;
+        CGFloat width = (CGFloat)CTLineGetTypographicBounds((__bridge CTLineRef)line, &ascent, &descent, &leading) ;
         
         for (id glyphRun in (__bridge NSArray *)CTLineGetGlyphRuns((__bridge CTLineRef)line)) {
             NSDictionary *attributes = (__bridge NSDictionary *)CTRunGetAttributes((__bridge CTRunRef) glyphRun);
             CGColorRef strokeColor = (__bridge CGColorRef)[attributes objectForKey:kBITBackgroundStrokeColorAttributeName];
             CGColorRef fillColor = (__bridge CGColorRef)[attributes objectForKey:kBITBackgroundFillColorAttributeName];
+            UIEdgeInsets fillPadding = [[attributes objectForKey:kBITBackgroundFillPaddingAttributeName] UIEdgeInsetsValue];
             CGFloat cornerRadius = [[attributes objectForKey:kBITBackgroundCornerRadiusAttributeName] floatValue];
             CGFloat lineWidth = [[attributes objectForKey:kBITBackgroundLineWidthAttributeName] floatValue];
-
+            
             if (strokeColor || fillColor) {
                 CGRect runBounds = CGRectZero;
-                CGFloat ascent = 0.0f;
-                CGFloat descent = 0.0f;
+                CGFloat runAscent = 0.0f;
+                CGFloat runDescent = 0.0f;
                 
-                runBounds.size.width = CTRunGetTypographicBounds((__bridge CTRunRef)glyphRun, CFRangeMake(0, 0), &ascent, &descent, NULL);
-                runBounds.size.height = ascent + descent;
+                runBounds.size.width = (CGFloat)CTRunGetTypographicBounds((__bridge CTRunRef)glyphRun, CFRangeMake(0, 0), &runAscent, &runDescent, NULL) + fillPadding.left + fillPadding.right;
+                runBounds.size.height = runAscent + runDescent + fillPadding.top + fillPadding.bottom;
                 
-                CGFloat xOffset = CTLineGetOffsetForStringIndex((__bridge CTLineRef)line, CTRunGetStringRange((__bridge CTRunRef)glyphRun).location, NULL);
-                runBounds.origin.x = origins[lineIndex].x + rect.origin.x + xOffset;
-                runBounds.origin.y = origins[lineIndex].y + rect.origin.y;
-                runBounds.origin.y -= descent;
-                
-                // Don't draw higlightedLinkBackground too far to the right
-                if (CGRectGetWidth(runBounds) > CGRectGetWidth(lineBounds)) {
-                    runBounds.size.width = CGRectGetWidth(lineBounds);
+                CGFloat xOffset = 0.0f;
+                CFRange glyphRange = CTRunGetStringRange((__bridge CTRunRef)glyphRun);
+                switch (CTRunGetStatus((__bridge CTRunRef)glyphRun)) {
+                    case kCTRunStatusRightToLeft:
+                        xOffset = CTLineGetOffsetForStringIndex((__bridge CTLineRef)line, glyphRange.location + glyphRange.length, NULL);
+                        break;
+                    default:
+                        xOffset = CTLineGetOffsetForStringIndex((__bridge CTLineRef)line, glyphRange.location, NULL);
+                        break;
                 }
                 
-                CGRect newRect = CGRectInset(CGRectInset(runBounds, -1.0f, -3.0f), lineWidth, lineWidth);
-                CGPathRef path = [[UIBezierPath bezierPathWithRoundedRect:newRect cornerRadius:cornerRadius] CGPath];
+                runBounds.origin.x = origins[lineIndex].x + rect.origin.x + xOffset - fillPadding.left - rect.origin.x;
+                runBounds.origin.y = origins[lineIndex].y + rect.origin.y - fillPadding.bottom - rect.origin.y;
+                runBounds.origin.y -= runDescent;
+                
+                // Don't draw higlightedLinkBackground too far to the right
+                if (CGRectGetWidth(runBounds) > width) {
+                    runBounds.size.width = width;
+                }
+                
+                CGPathRef path = [[UIBezierPath bezierPathWithRoundedRect:CGRectInset(UIEdgeInsetsInsetRect(runBounds, self.linkBackgroundEdgeInset), lineWidth, lineWidth) cornerRadius:cornerRadius] CGPath];
                 
                 CGContextSetLineJoin(c, kCGLineJoinRound);
                 
@@ -664,16 +1030,18 @@ static inline NSAttributedString * NSAttributedStringBySettingColorFromContext(N
     }
 }
 
-- (void)drawStrike:(CTFrameRef)frame inRect:(CGRect)rect context:(CGContextRef)c {
+- (void)drawStrike:(CTFrameRef)frame
+            inRect:(__unused CGRect)rect
+           context:(CGContextRef)c
+{
     NSArray *lines = (__bridge NSArray *)CTFrameGetLines(frame);
     CGPoint origins[[lines count]];
     CTFrameGetLineOrigins(frame, CFRangeMake(0, 0), origins);
     
     CFIndex lineIndex = 0;
-    for (id line in lines) {        
-        CGRect lineBounds = CTLineGetImageBounds((__bridge CTLineRef)line, c);
-        lineBounds.origin.x = origins[lineIndex].x;
-        lineBounds.origin.y = origins[lineIndex].y;
+    for (id line in lines) {
+        CGFloat ascent = 0.0f, descent = 0.0f, leading = 0.0f;
+        CGFloat width = (CGFloat)CTLineGetTypographicBounds((__bridge CTLineRef)line, &ascent, &descent, &leading) ;
         
         for (id glyphRun in (__bridge NSArray *)CTLineGetGlyphRuns((__bridge CTLineRef)line)) {
             NSDictionary *attributes = (__bridge NSDictionary *)CTRunGetAttributes((__bridge CTRunRef) glyphRun);
@@ -682,38 +1050,50 @@ static inline NSAttributedString * NSAttributedStringBySettingColorFromContext(N
             
             if (strikeOut) {
                 CGRect runBounds = CGRectZero;
-                CGFloat ascent = 0.0f;
-                CGFloat descent = 0.0f;
+                CGFloat runAscent = 0.0f;
+                CGFloat runDescent = 0.0f;
                 
-                runBounds.size.width = CTRunGetTypographicBounds((__bridge CTRunRef)glyphRun, CFRangeMake(0, 0), &ascent, &descent, NULL);
-                runBounds.size.height = ascent + descent;
+                runBounds.size.width = (CGFloat)CTRunGetTypographicBounds((__bridge CTRunRef)glyphRun, CFRangeMake(0, 0), &runAscent, &runDescent, NULL);
+                runBounds.size.height = runAscent + runDescent;
                 
-                CGFloat xOffset = CTLineGetOffsetForStringIndex((__bridge CTLineRef)line, CTRunGetStringRange((__bridge CTRunRef)glyphRun).location, NULL);
-                runBounds.origin.x = origins[lineIndex].x + rect.origin.x + xOffset;
-                runBounds.origin.y = origins[lineIndex].y + rect.origin.y;
-                runBounds.origin.y -= descent;
+                CGFloat xOffset = 0.0f;
+                CFRange glyphRange = CTRunGetStringRange((__bridge CTRunRef)glyphRun);
+                switch (CTRunGetStatus((__bridge CTRunRef)glyphRun)) {
+                    case kCTRunStatusRightToLeft:
+                        xOffset = CTLineGetOffsetForStringIndex((__bridge CTLineRef)line, glyphRange.location + glyphRange.length, NULL);
+                        break;
+                    default:
+                        xOffset = CTLineGetOffsetForStringIndex((__bridge CTLineRef)line, glyphRange.location, NULL);
+                        break;
+                }
+                runBounds.origin.x = origins[lineIndex].x + xOffset;
+                runBounds.origin.y = origins[lineIndex].y;
+                runBounds.origin.y -= runDescent;
                 
                 // Don't draw strikeout too far to the right
-                if (CGRectGetWidth(runBounds) > CGRectGetWidth(lineBounds)) {
-                    runBounds.size.width = CGRectGetWidth(lineBounds);
+                if (CGRectGetWidth(runBounds) > width) {
+                    runBounds.size.width = width;
                 }
                 
-				switch (superscriptStyle) {
-					case 1:
-						runBounds.origin.y -= ascent * 0.47f;
-						break;
-					case -1:
-						runBounds.origin.y += ascent * 0.25f;
-						break;
-					default:
-						break;
-				}
+                switch (superscriptStyle) {
+                    case 1:
+                        runBounds.origin.y -= runAscent * 0.47f;
+                        break;
+                    case -1:
+                        runBounds.origin.y += runAscent * 0.25f;
+                        break;
+                    default:
+                        break;
+                }
                 
                 // Use text color, or default to black
                 id color = [attributes objectForKey:(id)kCTForegroundColorAttributeName];
-
                 if (color) {
-                    CGContextSetStrokeColorWithColor(c, (__bridge CGColorRef)color);
+                    if ([color isKindOfClass:[UIColor class]]) {
+                        CGContextSetStrokeColorWithColor(c, [color CGColor]);
+                    } else {
+                        CGContextSetStrokeColorWithColor(c, (__bridge CGColorRef)color);
+                    }
                 } else {
                     CGContextSetGrayStrokeColor(c, 0.0f, 1.0);
                 }
@@ -721,7 +1101,8 @@ static inline NSAttributedString * NSAttributedStringBySettingColorFromContext(N
                 CTFontRef font = CTFontCreateWithName((__bridge CFStringRef)self.font.fontName, self.font.pointSize, NULL);
                 CGContextSetLineWidth(c, CTFontGetUnderlineThickness(font));
                 CFRelease(font);
-                CGFloat y = roundf(runBounds.origin.y + runBounds.size.height / 2.0f);
+                
+                CGFloat y = CGFloat_round(runBounds.origin.y + runBounds.size.height / 2.0f);
                 CGContextMoveToPoint(c, runBounds.origin.x, y);
                 CGContextAddLineToPoint(c, runBounds.origin.x + runBounds.size.width, y);
                 
@@ -733,30 +1114,58 @@ static inline NSAttributedString * NSAttributedStringBySettingColorFromContext(N
     }
 }
 
-#pragma mark - TTTAttributedLabel
+#pragma mark - BITAttributedLabel
 
 - (void)setText:(id)text {
+    NSParameterAssert(!text || [text isKindOfClass:[NSAttributedString class]] || [text isKindOfClass:[NSString class]]);
+    
     if ([text isKindOfClass:[NSString class]]) {
         [self setText:text afterInheritingLabelAttributesAndConfiguringWithBlock:nil];
         return;
     }
-    NSAssert([text isKindOfClass:[NSAttributedString class]], @"TTTAttributedLabel accepts either NSStrings or NSAttributedStrings");
-    NSAttributedString *attributedString = text;
-    self.attributedText = attributedString;
-
-    self.links = [NSArray array];
-    if (self.dataDetectorTypes != UIDataDetectorTypeNone) {
-        for (NSTextCheckingResult *result in [self detectedLinksInString:[self.attributedText string]
-                                                                   range:NSMakeRange(0, [attributedString length])
-                                                                   error:nil]) {
-            [self addLinkWithTextCheckingResult:result];
-        }
+    
+    self.attributedText = text;
+    self.activeLink = nil;
+    
+    self.linkModels = [NSArray array];
+    if (self.attributedText && self.enabledTextCheckingTypes) {
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < 50000
+        __unsafe_unretained __typeof(self)weakSelf = self;
+#else
+        __weak __typeof(self)weakSelf = self;
+#endif
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+            __strong __typeof(weakSelf)strongSelf = weakSelf;
+            
+            NSDataDetector *dataDetector = strongSelf.dataDetector;
+            if (dataDetector && [dataDetector respondsToSelector:@selector(matchesInString:options:range:)]) {
+                NSArray *results = [dataDetector matchesInString:[(NSAttributedString *)text string] options:0 range:NSMakeRange(0, [(NSAttributedString *)text length])];
+                if ([results count] > 0) {
+                    dispatch_sync(dispatch_get_main_queue(), ^{
+                        if ([[strongSelf.attributedText string] isEqualToString:[(NSAttributedString *)text string]]) {
+                            [strongSelf addLinksWithTextCheckingResults:results attributes:strongSelf.linkAttributes];
+                        }
+                    });
+                }
+            }
+        });
     }
-        
-    [super setText:[self.attributedText string]];
+    
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000
+    if (&NSLinkAttributeName) {
+        [self.attributedText enumerateAttribute:NSLinkAttributeName inRange:NSMakeRange(0, self.attributedText.length) options:0 usingBlock:^(id value, __unused NSRange range, __unused BOOL *stop) {
+            if (value) {
+                NSURL *URL = [value isKindOfClass:[NSString class]] ? [NSURL URLWithString:value] : value;
+                [self addLinkToURL:URL withRange:range];
+            }
+        }];
+    }
+#endif
 }
 
-- (void)setText:(id)text afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString *(^)(NSMutableAttributedString *mutableAttributedString))block {    
+- (void)setText:(id)text
+afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString * (^)(NSMutableAttributedString *mutableAttributedString))block
+{
     NSMutableAttributedString *mutableAttributedString = nil;
     if ([text isKindOfClass:[NSString class]]) {
         mutableAttributedString = [[NSMutableAttributedString alloc] initWithString:text attributes:NSAttributedStringAttributesFromLabel(self)];
@@ -772,6 +1181,33 @@ static inline NSAttributedString * NSAttributedStringBySettingColorFromContext(N
     [self setText:mutableAttributedString];
 }
 
+- (void)setActiveLink:(BITAttributedLabelLink *)activeLink {
+    _activeLink = activeLink;
+    
+    NSDictionary *activeAttributes = activeLink.activeAttributes ?: self.activeLinkAttributes;
+    
+    if (_activeLink && activeAttributes.count > 0) {
+        if (!self.inactiveAttributedText) {
+            self.inactiveAttributedText = [self.attributedText copy];
+        }
+        
+        NSMutableAttributedString *mutableAttributedString = [self.inactiveAttributedText mutableCopy];
+        if (self.activeLink.result.range.length > 0 && NSLocationInRange(NSMaxRange(self.activeLink.result.range) - 1, NSMakeRange(0, [self.inactiveAttributedText length]))) {
+            [mutableAttributedString addAttributes:activeAttributes range:self.activeLink.result.range];
+        }
+        
+        self.attributedText = mutableAttributedString;
+        [self setNeedsDisplay];
+        
+        [CATransaction flush];
+    } else if (self.inactiveAttributedText) {
+        self.attributedText = self.inactiveAttributedText;
+        self.inactiveAttributedText = nil;
+        
+        [self setNeedsDisplay];
+    }
+}
+
 #pragma mark - UILabel
 
 - (void)setHighlighted:(BOOL)highlighted {
@@ -781,18 +1217,18 @@ static inline NSAttributedString * NSAttributedStringBySettingColorFromContext(N
 
 // Fixes crash when loading from a UIStoryboard
 - (UIColor *)textColor {
-	UIColor *color = [super textColor];
-	if (!color) {
-		color = [UIColor blackColor];
-	}
-	
-	return color;
+    UIColor *color = [super textColor];
+    if (!color) {
+        color = [UIColor blackColor];
+    }
+    
+    return color;
 }
 
 - (void)setTextColor:(UIColor *)textColor {
     UIColor *oldTextColor = self.textColor;
     [super setTextColor:textColor];
-
+    
     // Redraw to allow any ColorFromContext attributes a chance to update
     if (textColor != oldTextColor) {
         [self setNeedsFramesetter];
@@ -800,225 +1236,659 @@ static inline NSAttributedString * NSAttributedStringBySettingColorFromContext(N
     }
 }
 
-- (CGRect)textRectForBounds:(CGRect)bounds limitedToNumberOfLines:(NSInteger)numberOfLines {
+- (CGRect)textRectForBounds:(CGRect)bounds
+     limitedToNumberOfLines:(NSInteger)numberOfLines
+{
+    bounds = UIEdgeInsetsInsetRect(bounds, self.textInsets);
     if (!self.attributedText) {
         return [super textRectForBounds:bounds limitedToNumberOfLines:numberOfLines];
     }
-        
+    
     CGRect textRect = bounds;
     
-    // Adjust the text to be in the center vertically, if the text size is smaller than bounds
-    CGSize textSize = CTFramesetterSuggestFrameSizeWithConstraints(self.framesetter, CFRangeMake(0, [self.attributedText length]), NULL, bounds.size, NULL);
-    textSize = CGSizeMake(ceilf(textSize.width), ceilf(textSize.height)); // Fix for iOS 4, CTFramesetterSuggestFrameSizeWithConstraints sometimes returns fractional sizes
+    // Calculate height with a minimum of double the font pointSize, to ensure that CTFramesetterSuggestFrameSizeWithConstraints doesn't return CGSizeZero, as it would if textRect height is insufficient.
+    textRect.size.height = MAX(self.font.lineHeight * MAX(2, numberOfLines), bounds.size.height);
     
-    if (textSize.height < textRect.size.height) {
-        CGFloat heightChange = (textRect.size.height - textSize.height);
+    // Adjust the text to be in the center vertically, if the text size is smaller than bounds
+    CGSize textSize = CTFramesetterSuggestFrameSizeWithConstraints([self framesetter], CFRangeMake(0, (CFIndex)[self.attributedText length]), NULL, textRect.size, NULL);
+    textSize = CGSizeMake(CGFloat_ceil(textSize.width), CGFloat_ceil(textSize.height)); // Fix for iOS 4, CTFramesetterSuggestFrameSizeWithConstraints sometimes returns fractional sizes
+    
+    if (textSize.height < bounds.size.height) {
         CGFloat yOffset = 0.0f;
         switch (self.verticalAlignment) {
-            case BITAttributedLabelVerticalAlignmentTop:
-                heightChange = 0.0f;
-                break;
             case BITAttributedLabelVerticalAlignmentCenter:
-                yOffset = floorf((textRect.size.height - textSize.height) / 2.0f);
+                yOffset = CGFloat_floor((bounds.size.height - textSize.height) / 2.0f);
                 break;
             case BITAttributedLabelVerticalAlignmentBottom:
-                yOffset = textRect.size.height - textSize.height;
+                yOffset = bounds.size.height - textSize.height;
+                break;
+            case BITAttributedLabelVerticalAlignmentTop:
+            default:
                 break;
         }
         
         textRect.origin.y += yOffset;
-        textRect.size = CGSizeMake(textRect.size.width, textRect.size.height - heightChange + yOffset);
     }
     
     return textRect;
 }
 
 - (void)drawTextInRect:(CGRect)rect {
+    CGRect insetRect = UIEdgeInsetsInsetRect(rect, self.textInsets);
     if (!self.attributedText) {
-        [super drawTextInRect:rect];
+        [super drawTextInRect:insetRect];
         return;
     }
-        
+    
     NSAttributedString *originalAttributedText = nil;
     
-    // Adjust the font size to fit width, if necessary
+    // Adjust the font size to fit width, if necessarry
     if (self.adjustsFontSizeToFitWidth && self.numberOfLines > 0) {
-        CGFloat textWidth = [self sizeThatFits:CGSizeZero].width;
+        // Use infinite width to find the max width, which will be compared to availableWidth if needed.
+        CGSize maxSize = (self.numberOfLines > 1) ? CGSizeMake(BITFLOAT_MAX, BITFLOAT_MAX) : CGSizeZero;
+        
+        CGFloat textWidth = [self sizeThatFits:maxSize].width;
         CGFloat availableWidth = self.frame.size.width * self.numberOfLines;
-        if (self.numberOfLines > 1 && self.lineBreakMode == UILineBreakModeWordWrap) {
+        if (self.numberOfLines > 1 && self.lineBreakMode == BITLineBreakByWordWrapping) {
             textWidth *= kBITLineBreakWordWrapTextWidthScalingFactor;
         }
         
         if (textWidth > availableWidth && textWidth > 0.0f) {
             originalAttributedText = [self.attributedText copy];
-            self.text = NSAttributedStringByScalingFontSize(self.attributedText, availableWidth / textWidth, self.minimumFontSize);
+            
+            CGFloat scaleFactor = availableWidth / textWidth;
+            if ([self respondsToSelector:@selector(minimumScaleFactor)] && self.minimumScaleFactor > scaleFactor) {
+                scaleFactor = self.minimumScaleFactor;
+            }
+            
+            self.attributedText = NSAttributedStringByScalingFontSize(self.attributedText, scaleFactor);
         }
     }
     
     CGContextRef c = UIGraphicsGetCurrentContext();
-    CGContextSetTextMatrix(c, CGAffineTransformIdentity);
-
-    // Inverts the CTM to match iOS coordinates (otherwise text draws upside-down; Mac OS's system is different)
-    CGContextTranslateCTM(c, 0.0f, rect.size.height);
-    CGContextScaleCTM(c, 1.0f, -1.0f);
-    
-    CFRange textRange = CFRangeMake(0, [self.attributedText length]);
-
-    // First, get the text rect (which takes vertical centering into account)
-    CGRect textRect = [self textRectForBounds:rect limitedToNumberOfLines:self.numberOfLines];
-
-    // CoreText draws it's text aligned to the bottom, so we move the CTM here to take our vertical offsets into account
-    CGContextTranslateCTM(c, 0.0f, rect.size.height - textRect.origin.y - textRect.size.height);
-
-    // Second, trace the shadow before the actual text, if we have one
-    if (self.shadowColor && !self.highlighted) {
-        CGContextSetShadowWithColor(c, self.shadowOffset, self.shadowRadius, [self.shadowColor CGColor]);
-    }
-    
-    // Finally, draw the text or highlighted text itself (on top of the shadow, if there is one)
-    if (self.highlightedTextColor && self.highlighted) {
-        NSMutableAttributedString *highlightAttributedString = [self.renderedAttributedText mutableCopy];
-        [highlightAttributedString addAttribute:(NSString *)kCTForegroundColorAttributeName value:(id)[self.highlightedTextColor CGColor] range:NSMakeRange(0, highlightAttributedString.length)];
+    CGContextSaveGState(c);
+    {
+        CGContextSetTextMatrix(c, CGAffineTransformIdentity);
         
-        if (!_highlightFramesetter) {
-            _highlightFramesetter = CTFramesetterCreateWithAttributedString((__bridge CFAttributedStringRef)highlightAttributedString);
+        // Inverts the CTM to match iOS coordinates (otherwise text draws upside-down; Mac OS's system is different)
+        CGContextTranslateCTM(c, 0.0f, insetRect.size.height);
+        CGContextScaleCTM(c, 1.0f, -1.0f);
+        
+        CFRange textRange = CFRangeMake(0, (CFIndex)[self.attributedText length]);
+        
+        // First, get the text rect (which takes vertical centering into account)
+        CGRect textRect = [self textRectForBounds:rect limitedToNumberOfLines:self.numberOfLines];
+        
+        // CoreText draws its text aligned to the bottom, so we move the CTM here to take our vertical offsets into account
+        CGContextTranslateCTM(c, insetRect.origin.x, insetRect.size.height - textRect.origin.y - textRect.size.height);
+        
+        // Second, trace the shadow before the actual text, if we have one
+        if (self.shadowColor && !self.highlighted) {
+            CGContextSetShadowWithColor(c, self.shadowOffset, self.shadowRadius, [self.shadowColor CGColor]);
+        } else if (self.highlightedShadowColor) {
+            CGContextSetShadowWithColor(c, self.highlightedShadowOffset, self.highlightedShadowRadius, [self.highlightedShadowColor CGColor]);
         }
         
-        [self drawFramesetter:self.highlightFramesetter attributedString:highlightAttributedString textRange:textRange inRect:textRect context:c];
-    } else {
-        [self drawFramesetter:self.framesetter attributedString:self.renderedAttributedText textRange:textRange inRect:textRect context:c];
-    }  
-    
-    // If we adjusted the font size, set it back to its original size
-    if (originalAttributedText) {
-        self.text = originalAttributedText;
+        // Finally, draw the text or highlighted text itself (on top of the shadow, if there is one)
+        if (self.highlightedTextColor && self.highlighted) {
+            NSMutableAttributedString *highlightAttributedString = [self.renderedAttributedText mutableCopy];
+            [highlightAttributedString addAttribute:(__bridge NSString *)kCTForegroundColorAttributeName value:(id)[self.highlightedTextColor CGColor] range:NSMakeRange(0, highlightAttributedString.length)];
+            
+            if (![self highlightFramesetter]) {
+                CTFramesetterRef highlightFramesetter = CTFramesetterCreateWithAttributedString((__bridge CFAttributedStringRef)highlightAttributedString);
+                [self setHighlightFramesetter:highlightFramesetter];
+                CFRelease(highlightFramesetter);
+            }
+            
+            [self drawFramesetter:[self highlightFramesetter] attributedString:highlightAttributedString textRange:textRange inRect:textRect context:c];
+        } else {
+            [self drawFramesetter:[self framesetter] attributedString:self.renderedAttributedText textRange:textRange inRect:textRect context:c];
+        }
+        
+        // If we adjusted the font size, set it back to its original size
+        if (originalAttributedText) {
+            // Use ivar directly to avoid clearing out framesetter and renderedAttributedText
+            _attributedText = originalAttributedText;
+        }
     }
+    CGContextRestoreGState(c);
 }
+
+#pragma mark - UIAccessibilityElement
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000
+
+- (BOOL)isAccessibilityElement {
+    return NO;
+}
+
+- (NSInteger)accessibilityElementCount {
+    return (NSInteger)[[self accessibilityElements] count];
+}
+
+- (id)accessibilityElementAtIndex:(NSInteger)index {
+    return [[self accessibilityElements] objectAtIndex:(NSUInteger)index];
+}
+
+- (NSInteger)indexOfAccessibilityElement:(id)element {
+    return (NSInteger)[[self accessibilityElements] indexOfObject:element];
+}
+
+- (NSArray *)accessibilityElements {
+    if (!_accessibilityElements) {
+        @synchronized(self) {
+            NSMutableArray *mutableAccessibilityItems = [NSMutableArray array];
+            
+            for (BITAttributedLabelLink *link in self.linkModels) {
+                
+                if (link.result.range.location == NSNotFound) {
+                    continue;
+                }
+                
+                NSString *sourceText = [self.text isKindOfClass:[NSString class]] ? self.text : [(NSAttributedString *)self.text string];
+                
+                NSString *accessibilityLabel = [sourceText substringWithRange:link.result.range];
+                NSString *accessibilityValue = link.accessibilityValue;
+                
+                if (accessibilityLabel) {
+                    UIAccessibilityElement *linkElement = [[UIAccessibilityElement alloc] initWithAccessibilityContainer:self];
+                    linkElement.accessibilityTraits = UIAccessibilityTraitLink;
+                    linkElement.accessibilityFrame = [self convertRect:[self boundingRectForCharacterRange:link.result.range] toView:self.window];
+                    linkElement.accessibilityLabel = accessibilityLabel;
+                    
+                    if (![accessibilityLabel isEqualToString:accessibilityValue]) {
+                        linkElement.accessibilityValue = accessibilityValue;
+                    }
+                    
+                    [mutableAccessibilityItems addObject:linkElement];
+                }
+            }
+            
+            UIAccessibilityElement *baseElement = [[UIAccessibilityElement alloc] initWithAccessibilityContainer:self];
+            baseElement.accessibilityLabel = [super accessibilityLabel];
+            baseElement.accessibilityHint = [super accessibilityHint];
+            baseElement.accessibilityValue = [super accessibilityValue];
+            baseElement.accessibilityFrame = [self convertRect:self.bounds toView:self.window];
+            baseElement.accessibilityTraits = [super accessibilityTraits];
+            
+            [mutableAccessibilityItems addObject:baseElement];
+            
+            self.accessibilityElements = [NSArray arrayWithArray:mutableAccessibilityItems];
+        }
+    }
+    
+    return _accessibilityElements;
+}
+#endif
 
 #pragma mark - UIView
 
 - (CGSize)sizeThatFits:(CGSize)size {
     if (!self.attributedText) {
         return [super sizeThatFits:size];
-    }
-    
-    CFRange rangeToSize = CFRangeMake(0, [self.attributedText length]);
-    CGSize constraints = CGSizeMake(size.width, CGFLOAT_MAX);
-    
-    if (self.numberOfLines == 1) {
-        // If there is one line, the size that fits is the full width of the line
-        constraints = CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX);
-    } else if (self.numberOfLines > 0) {
-        // If the line count of the label more than 1, limit the range to size to the number of lines that have been set
-        CGMutablePathRef path = CGPathCreateMutable();
-        CGPathAddRect(path, NULL, CGRectMake(0.0f, 0.0f, constraints.width, CGFLOAT_MAX));
-        CTFrameRef frame = CTFramesetterCreateFrame(self.framesetter, CFRangeMake(0, 0), path, NULL);
-        CFArrayRef lines = CTFrameGetLines(frame);
+    } else {
+        NSMutableAttributedString *fullString = [[NSMutableAttributedString alloc] initWithAttributedString:self.attributedText];
         
-        if (CFArrayGetCount(lines) > 0) {
-            NSInteger lastVisibleLineIndex = MIN(self.numberOfLines, CFArrayGetCount(lines)) - 1;
-            CTLineRef lastVisibleLine = CFArrayGetValueAtIndex(lines, lastVisibleLineIndex);
-            
-            CFRange rangeToLayout = CTLineGetStringRange(lastVisibleLine);
-            rangeToSize = CFRangeMake(0, rangeToLayout.location + rangeToLayout.length);
+        if (self.attributedTruncationToken) {
+            [fullString appendAttributedString:self.attributedTruncationToken];
         }
         
-        CFRelease(frame);
-        CFRelease(path);
+        NSAttributedString *string = [[NSAttributedString alloc] initWithAttributedString:fullString];
+        
+        CGSize labelSize = CTFramesetterSuggestFrameSizeForAttributedStringWithConstraints([self framesetter], string, size, (NSUInteger)self.numberOfLines);
+        labelSize.width += self.textInsets.left + self.textInsets.right;
+        labelSize.height += self.textInsets.top + self.textInsets.bottom;
+        
+        return labelSize;
+    }
+}
+
+- (CGSize)intrinsicContentSize {
+    // There's an implicit width from the original UILabel implementation
+    return [self sizeThatFits:[super intrinsicContentSize]];
+}
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000
+- (void)tintColorDidChange {
+    if (!self.inactiveLinkAttributes || [self.inactiveLinkAttributes count] == 0) {
+        return;
     }
     
-    CGSize suggestedSize = CTFramesetterSuggestFrameSizeWithConstraints(self.framesetter, rangeToSize, NULL, constraints, NULL);
+    BOOL isInactive = (self.tintAdjustmentMode == UIViewTintAdjustmentModeDimmed);
     
-    return CGSizeMake(ceilf(suggestedSize.width), ceilf(suggestedSize.height));
+    NSMutableAttributedString *mutableAttributedString = [self.attributedText mutableCopy];
+    for (BITAttributedLabelLink *link in self.linkModels) {
+        NSDictionary *attributesToRemove = isInactive ? link.attributes : link.inactiveAttributes;
+        NSDictionary *attributesToAdd = isInactive ? link.inactiveAttributes : link.attributes;
+        
+        [attributesToRemove enumerateKeysAndObjectsUsingBlock:^(NSString *name, __unused id value, __unused BOOL *stop) {
+            if (NSMaxRange(link.result.range) <= mutableAttributedString.length) {
+                [mutableAttributedString removeAttribute:name range:link.result.range];
+            }
+        }];
+        
+        if (attributesToAdd) {
+            if (NSMaxRange(link.result.range) <= mutableAttributedString.length) {
+                [mutableAttributedString addAttributes:attributesToAdd range:link.result.range];
+            }
+        }
+    }
+    
+    self.attributedText = mutableAttributedString;
+    
+    [self setNeedsDisplay];
+}
+#endif
+
+- (UIView *)hitTest:(CGPoint)point
+          withEvent:(UIEvent *)event
+{
+    if (![self linkAtPoint:point] || !self.userInteractionEnabled || self.hidden || self.alpha < 0.01) {
+        return [super hitTest:point withEvent:event];
+    }
+    
+    return self;
 }
 
 #pragma mark - UIResponder
 
-- (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {
+- (BOOL)canBecomeFirstResponder {
+    return YES;
+}
+
+- (BOOL)canPerformAction:(SEL)action
+              withSender:(__unused id)sender
+{
+    return (action == @selector(copy:));
+}
+
+- (void)touchesBegan:(NSSet *)touches
+           withEvent:(UIEvent *)event
+{
     UITouch *touch = [touches anyObject];
     
     self.activeLink = [self linkAtPoint:[touch locationInView:self]];
-        
-    if (self.activeLink) {
-        [self setLinkActive:YES withTextCheckingResult:self.activeLink];
-    } else {
+    
+    if (!self.activeLink) {
         [super touchesBegan:touches withEvent:event];
     }
 }
 
-- (void)touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event {    
+- (void)touchesMoved:(NSSet *)touches
+           withEvent:(UIEvent *)event
+{
     if (self.activeLink) {
         UITouch *touch = [touches anyObject];
         
         if (self.activeLink != [self linkAtPoint:[touch locationInView:self]]) {
-            [self setLinkActive:NO withTextCheckingResult:self.activeLink];
-        } else {
-            [self setLinkActive:YES withTextCheckingResult:self.activeLink];
+            self.activeLink = nil;
         }
     } else {
         [super touchesMoved:touches withEvent:event];
     }
 }
 
-- (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event {
-    NSTextCheckingResult *activeLink = self.activeLink;
-    if (activeLink) {
-        UITouch *touch = [touches anyObject];
-        if (activeLink == [self linkAtPoint:[touch locationInView:self]]) {
-            [self setLinkActive:NO withTextCheckingResult:activeLink];
-            
-            if (!self.delegate) {
-                return;
-            }
-            
-            switch (activeLink.resultType) {
-                case NSTextCheckingTypeLink:
-                    if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithURL:)]) {
-                        [self.delegate attributedLabel:self didSelectLinkWithURL:activeLink.URL];
-                        return;
-                    }
-                    break;
-                case NSTextCheckingTypeAddress:
-                    if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithAddress:)]) {
-                        [self.delegate attributedLabel:self didSelectLinkWithAddress:activeLink.addressComponents];
-                        return;
-                    }
-                    break;
-                case NSTextCheckingTypePhoneNumber:
-                    if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithPhoneNumber:)]) {
-                        [self.delegate attributedLabel:self didSelectLinkWithPhoneNumber:activeLink.phoneNumber];
-                        return;
-                    }
-                    break;
-                case NSTextCheckingTypeDate:
-                    if (activeLink.timeZone && [self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithDate:timeZone:duration:)]) {
-                        [self.delegate attributedLabel:self didSelectLinkWithDate:activeLink.date timeZone:activeLink.timeZone duration:activeLink.duration];
-                        return;
-                    } else if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithDate:)]) {
-                        [self.delegate attributedLabel:self didSelectLinkWithDate:activeLink.date];
-                        return;
-                    }
-                    break;
-                default:
-                    break;
-            }
-            
-            // Fallback to `attributedLabel:didSelectLinkWithTextCheckingResult:` if no other delegate method matched.
-            if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithTextCheckingResult:)]) {
-                [self.delegate attributedLabel:self didSelectLinkWithTextCheckingResult:activeLink];
-            }
+- (void)touchesEnded:(NSSet *)touches
+           withEvent:(UIEvent *)event
+{
+    if (self.activeLink) {
+        if (self.activeLink.linkTapBlock) {
+            self.activeLink.linkTapBlock(self, self.activeLink);
+            self.activeLink = nil;
+            return;
+        }
+        
+        NSTextCheckingResult *result = self.activeLink.result;
+        self.activeLink = nil;
+        
+        switch (result.resultType) {
+            case NSTextCheckingTypeLink:
+                if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithURL:)]) {
+                    [self.delegate attributedLabel:self didSelectLinkWithURL:result.URL];
+                    return;
+                }
+                break;
+            case NSTextCheckingTypeAddress:
+                if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithAddress:)]) {
+                    [self.delegate attributedLabel:self didSelectLinkWithAddress:result.addressComponents];
+                    return;
+                }
+                break;
+            case NSTextCheckingTypePhoneNumber:
+                if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithPhoneNumber:)]) {
+                    [self.delegate attributedLabel:self didSelectLinkWithPhoneNumber:result.phoneNumber];
+                    return;
+                }
+                break;
+            case NSTextCheckingTypeDate:
+                if (result.timeZone && [self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithDate:timeZone:duration:)]) {
+                    [self.delegate attributedLabel:self didSelectLinkWithDate:result.date timeZone:result.timeZone duration:result.duration];
+                    return;
+                } else if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithDate:)]) {
+                    [self.delegate attributedLabel:self didSelectLinkWithDate:result.date];
+                    return;
+                }
+                break;
+            case NSTextCheckingTypeTransitInformation:
+                if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithTransitInformation:)]) {
+                    [self.delegate attributedLabel:self didSelectLinkWithTransitInformation:result.components];
+                    return;
+                }
+            default:
+                break;
+        }
+        
+        // Fallback to `attributedLabel:didSelectLinkWithTextCheckingResult:` if no other delegate method matched.
+        if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithTextCheckingResult:)]) {
+            [self.delegate attributedLabel:self didSelectLinkWithTextCheckingResult:result];
         }
     } else {
         [super touchesEnded:touches withEvent:event];
     }
 }
 
-- (void)touchesCancelled:(NSSet *)touches withEvent:(UIEvent *)event {
+- (void)touchesCancelled:(NSSet *)touches
+               withEvent:(UIEvent *)event
+{
     if (self.activeLink) {
-        [self setLinkActive:NO withTextCheckingResult:self.activeLink];
+        self.activeLink = nil;
     } else {
         [super touchesCancelled:touches withEvent:event];
     }
+}
+
+#pragma mark - UIGestureRecognizerDelegate
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch {
+    return [self containslinkAtPoint:[touch locationInView:self]];
+}
+
+#pragma mark - UILongPressGestureRecognizer
+
+- (void)longPressGestureDidFire:(UILongPressGestureRecognizer *)sender {
+    switch (sender.state) {
+        case UIGestureRecognizerStateBegan: {
+            CGPoint touchPoint = [sender locationInView:self];
+            BITAttributedLabelLink *link = [self linkAtPoint:touchPoint];
+            
+            if (link) {
+                if (link.linkLongPressBlock) {
+                    link.linkLongPressBlock(self, link);
+                    return;
+                }
+                
+                NSTextCheckingResult *result = link.result;
+                
+                if (!result) {
+                    return;
+                }
+                
+                switch (result.resultType) {
+                    case NSTextCheckingTypeLink:
+                        if ([self.delegate respondsToSelector:@selector(attributedLabel:didLongPressLinkWithURL:atPoint:)]) {
+                            [self.delegate attributedLabel:self didLongPressLinkWithURL:result.URL atPoint:touchPoint];
+                            return;
+                        }
+                        break;
+                    case NSTextCheckingTypeAddress:
+                        if ([self.delegate respondsToSelector:@selector(attributedLabel:didLongPressLinkWithAddress:atPoint:)]) {
+                            [self.delegate attributedLabel:self didLongPressLinkWithAddress:result.addressComponents atPoint:touchPoint];
+                            return;
+                        }
+                        break;
+                    case NSTextCheckingTypePhoneNumber:
+                        if ([self.delegate respondsToSelector:@selector(attributedLabel:didLongPressLinkWithPhoneNumber:atPoint:)]) {
+                            [self.delegate attributedLabel:self didLongPressLinkWithPhoneNumber:result.phoneNumber atPoint:touchPoint];
+                            return;
+                        }
+                        break;
+                    case NSTextCheckingTypeDate:
+                        if (result.timeZone && [self.delegate respondsToSelector:@selector(attributedLabel:didLongPressLinkWithDate:timeZone:duration:atPoint:)]) {
+                            [self.delegate attributedLabel:self didLongPressLinkWithDate:result.date timeZone:result.timeZone duration:result.duration atPoint:touchPoint];
+                            return;
+                        } else if ([self.delegate respondsToSelector:@selector(attributedLabel:didLongPressLinkWithDate:atPoint:)]) {
+                            [self.delegate attributedLabel:self didLongPressLinkWithDate:result.date atPoint:touchPoint];
+                            return;
+                        }
+                        break;
+                    case NSTextCheckingTypeTransitInformation:
+                        if ([self.delegate respondsToSelector:@selector(attributedLabel:didLongPressLinkWithTransitInformation:atPoint:)]) {
+                            [self.delegate attributedLabel:self didLongPressLinkWithTransitInformation:result.components atPoint:touchPoint];
+                            return;
+                        }
+                    default:
+                        break;
+                }
+                
+                // Fallback to `attributedLabel:didLongPressLinkWithTextCheckingResult:atPoint:` if no other delegate method matched.
+                if ([self.delegate respondsToSelector:@selector(attributedLabel:didLongPressLinkWithTextCheckingResult:atPoint:)]) {
+                    [self.delegate attributedLabel:self didLongPressLinkWithTextCheckingResult:result atPoint:touchPoint];
+                }
+            }
+            break;
+        }
+        default:
+            break;
+    }
+}
+
+#pragma mark - UIResponderStandardEditActions
+
+- (void)copy:(__unused id)sender {
+    [[UIPasteboard generalPasteboard] setString:self.text];
+}
+
+#pragma mark - NSCoding
+
+- (void)encodeWithCoder:(NSCoder *)coder {
+    [super encodeWithCoder:coder];
+    
+    [coder encodeObject:@(self.enabledTextCheckingTypes) forKey:NSStringFromSelector(@selector(enabledTextCheckingTypes))];
+    
+    [coder encodeObject:self.linkModels forKey:NSStringFromSelector(@selector(linkModels))];
+    if ([NSMutableParagraphStyle class]) {
+        [coder encodeObject:self.linkAttributes forKey:NSStringFromSelector(@selector(linkAttributes))];
+        [coder encodeObject:self.activeLinkAttributes forKey:NSStringFromSelector(@selector(activeLinkAttributes))];
+        [coder encodeObject:self.inactiveLinkAttributes forKey:NSStringFromSelector(@selector(inactiveLinkAttributes))];
+    }
+    [coder encodeObject:@(self.shadowRadius) forKey:NSStringFromSelector(@selector(shadowRadius))];
+    [coder encodeObject:@(self.highlightedShadowRadius) forKey:NSStringFromSelector(@selector(highlightedShadowRadius))];
+    [coder encodeCGSize:self.highlightedShadowOffset forKey:NSStringFromSelector(@selector(highlightedShadowOffset))];
+    [coder encodeObject:self.highlightedShadowColor forKey:NSStringFromSelector(@selector(highlightedShadowColor))];
+    [coder encodeObject:@(self.kern) forKey:NSStringFromSelector(@selector(kern))];
+    [coder encodeObject:@(self.firstLineIndent) forKey:NSStringFromSelector(@selector(firstLineIndent))];
+    [coder encodeObject:@(self.lineSpacing) forKey:NSStringFromSelector(@selector(lineSpacing))];
+    [coder encodeObject:@(self.lineHeightMultiple) forKey:NSStringFromSelector(@selector(lineHeightMultiple))];
+    [coder encodeUIEdgeInsets:self.textInsets forKey:NSStringFromSelector(@selector(textInsets))];
+    [coder encodeInteger:self.verticalAlignment forKey:NSStringFromSelector(@selector(verticalAlignment))];
+    
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    [coder encodeObject:self.truncationTokenString forKey:NSStringFromSelector(@selector(truncationTokenString))];
+#pragma clang diagnostic pop
+    
+    [coder encodeObject:NSStringFromUIEdgeInsets(self.linkBackgroundEdgeInset) forKey:NSStringFromSelector(@selector(linkBackgroundEdgeInset))];
+    [coder encodeObject:self.attributedText forKey:NSStringFromSelector(@selector(attributedText))];
+    [coder encodeObject:self.text forKey:NSStringFromSelector(@selector(text))];
+}
+
+- (id)initWithCoder:(NSCoder *)coder {
+    self = [super initWithCoder:coder];
+    if (!self) {
+        return nil;
+    }
+    
+    [self commonInit];
+    
+    if ([coder containsValueForKey:NSStringFromSelector(@selector(enabledTextCheckingTypes))]) {
+        self.enabledTextCheckingTypes = [[coder decodeObjectForKey:NSStringFromSelector(@selector(enabledTextCheckingTypes))] unsignedLongLongValue];
+    }
+    
+    if ([NSMutableParagraphStyle class]) {
+        if ([coder containsValueForKey:NSStringFromSelector(@selector(linkAttributes))]) {
+            self.linkAttributes = [coder decodeObjectForKey:NSStringFromSelector(@selector(linkAttributes))];
+        }
+        
+        if ([coder containsValueForKey:NSStringFromSelector(@selector(activeLinkAttributes))]) {
+            self.activeLinkAttributes = [coder decodeObjectForKey:NSStringFromSelector(@selector(activeLinkAttributes))];
+        }
+        
+        if ([coder containsValueForKey:NSStringFromSelector(@selector(inactiveLinkAttributes))]) {
+            self.inactiveLinkAttributes = [coder decodeObjectForKey:NSStringFromSelector(@selector(inactiveLinkAttributes))];
+        }
+    }
+    
+    if ([coder containsValueForKey:NSStringFromSelector(@selector(links))]) {
+        NSArray *oldLinks = [coder decodeObjectForKey:NSStringFromSelector(@selector(links))];
+        [self addLinksWithTextCheckingResults:oldLinks attributes:nil];
+    }
+    
+    if ([coder containsValueForKey:NSStringFromSelector(@selector(linkModels))]) {
+        self.linkModels = [coder decodeObjectForKey:NSStringFromSelector(@selector(linkModels))];
+    }
+    
+    if ([coder containsValueForKey:NSStringFromSelector(@selector(shadowRadius))]) {
+        self.shadowRadius = [[coder decodeObjectForKey:NSStringFromSelector(@selector(shadowRadius))] floatValue];
+    }
+    
+    if ([coder containsValueForKey:NSStringFromSelector(@selector(highlightedShadowRadius))]) {
+        self.highlightedShadowRadius = [[coder decodeObjectForKey:NSStringFromSelector(@selector(highlightedShadowRadius))] floatValue];
+    }
+    
+    if ([coder containsValueForKey:NSStringFromSelector(@selector(highlightedShadowOffset))]) {
+        self.highlightedShadowOffset = [coder decodeCGSizeForKey:NSStringFromSelector(@selector(highlightedShadowOffset))];
+    }
+    
+    if ([coder containsValueForKey:NSStringFromSelector(@selector(highlightedShadowColor))]) {
+        self.highlightedShadowColor = [coder decodeObjectForKey:NSStringFromSelector(@selector(highlightedShadowColor))];
+    }
+    
+    if ([coder containsValueForKey:NSStringFromSelector(@selector(kern))]) {
+        self.kern = [[coder decodeObjectForKey:NSStringFromSelector(@selector(kern))] floatValue];
+    }
+    
+    if ([coder containsValueForKey:NSStringFromSelector(@selector(firstLineIndent))]) {
+        self.firstLineIndent = [[coder decodeObjectForKey:NSStringFromSelector(@selector(firstLineIndent))] floatValue];
+    }
+    
+    if ([coder containsValueForKey:NSStringFromSelector(@selector(lineSpacing))]) {
+        self.lineSpacing = [[coder decodeObjectForKey:NSStringFromSelector(@selector(lineSpacing))] floatValue];
+    }
+    
+    if ([coder containsValueForKey:NSStringFromSelector(@selector(minimumLineHeight))]) {
+        self.minimumLineHeight = [[coder decodeObjectForKey:NSStringFromSelector(@selector(minimumLineHeight))] floatValue];
+    }
+    
+    if ([coder containsValueForKey:NSStringFromSelector(@selector(maximumLineHeight))]) {
+        self.maximumLineHeight = [[coder decodeObjectForKey:NSStringFromSelector(@selector(maximumLineHeight))] floatValue];
+    }
+    
+    if ([coder containsValueForKey:NSStringFromSelector(@selector(lineHeightMultiple))]) {
+        self.lineHeightMultiple = [[coder decodeObjectForKey:NSStringFromSelector(@selector(lineHeightMultiple))] floatValue];
+    }
+    
+    if ([coder containsValueForKey:NSStringFromSelector(@selector(textInsets))]) {
+        self.textInsets = [coder decodeUIEdgeInsetsForKey:NSStringFromSelector(@selector(textInsets))];
+    }
+    
+    if ([coder containsValueForKey:NSStringFromSelector(@selector(verticalAlignment))]) {
+        self.verticalAlignment = [coder decodeIntegerForKey:NSStringFromSelector(@selector(verticalAlignment))];
+    }
+    
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    if ([coder containsValueForKey:NSStringFromSelector(@selector(truncationTokenString))]) {
+        self.truncationTokenString = [coder decodeObjectForKey:NSStringFromSelector(@selector(truncationTokenString))];
+    }
+#pragma clang diagnostic pop
+    
+    if ([coder containsValueForKey:NSStringFromSelector(@selector(linkBackgroundEdgeInset))]) {
+        self.linkBackgroundEdgeInset = UIEdgeInsetsFromString([coder decodeObjectForKey:NSStringFromSelector(@selector(linkBackgroundEdgeInset))]);
+    }
+    
+    if ([coder containsValueForKey:NSStringFromSelector(@selector(attributedText))]) {
+        self.attributedText = [coder decodeObjectForKey:NSStringFromSelector(@selector(attributedText))];
+    } else {
+        self.text = super.text;
+    }
+    
+    return self;
+}
+
+@end
+
+#pragma mark - BITAttributedLabelLink
+
+@implementation BITAttributedLabelLink
+
+- (instancetype)initWithAttributes:(NSDictionary *)attributes
+                  activeAttributes:(NSDictionary *)activeAttributes
+                inactiveAttributes:(NSDictionary *)inactiveAttributes
+                textCheckingResult:(NSTextCheckingResult *)result {
+    
+    if ((self = [super init])) {
+        _result = result;
+        _attributes = [attributes copy];
+        _activeAttributes = [activeAttributes copy];
+        _inactiveAttributes = [inactiveAttributes copy];
+    }
+    
+    return self;
+}
+
+- (instancetype)initWithAttributesFromLabel:(BITAttributedLabel*)label
+                         textCheckingResult:(NSTextCheckingResult *)result {
+    
+    return [self initWithAttributes:label.linkAttributes
+                   activeAttributes:label.activeLinkAttributes
+                 inactiveAttributes:label.inactiveLinkAttributes
+                 textCheckingResult:result];
+}
+
+#pragma mark - Accessibility
+
+- (NSString *) accessibilityValue {
+    if ([_accessibilityValue length] == 0) {
+        switch (self.result.resultType) {
+            case NSTextCheckingTypeLink:
+                _accessibilityValue = self.result.URL.absoluteString;
+                break;
+            case NSTextCheckingTypePhoneNumber:
+                _accessibilityValue = self.result.phoneNumber;
+                break;
+            case NSTextCheckingTypeDate:
+                _accessibilityValue = [NSDateFormatter localizedStringFromDate:self.result.date
+                                                                     dateStyle:NSDateFormatterLongStyle
+                                                                     timeStyle:NSDateFormatterLongStyle];
+                break;
+            default:
+                break;
+        }
+    }
+    
+    return _accessibilityValue;
+}
+
+#pragma mark - NSCoding
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+    [aCoder encodeObject:self.result forKey:NSStringFromSelector(@selector(result))];
+    [aCoder encodeObject:self.attributes forKey:NSStringFromSelector(@selector(attributes))];
+    [aCoder encodeObject:self.activeAttributes forKey:NSStringFromSelector(@selector(activeAttributes))];
+    [aCoder encodeObject:self.inactiveAttributes forKey:NSStringFromSelector(@selector(inactiveAttributes))];
+    [aCoder encodeObject:self.accessibilityValue forKey:NSStringFromSelector(@selector(accessibilityValue))];
+}
+
+- (id)initWithCoder:(NSCoder *)aDecoder {
+    if ((self = [super init])) {
+        _result = [aDecoder decodeObjectForKey:NSStringFromSelector(@selector(result))];
+        _attributes = [aDecoder decodeObjectForKey:NSStringFromSelector(@selector(attributes))];
+        _activeAttributes = [aDecoder decodeObjectForKey:NSStringFromSelector(@selector(activeAttributes))];
+        _inactiveAttributes = [aDecoder decodeObjectForKey:NSStringFromSelector(@selector(inactiveAttributes))];
+        self.accessibilityValue = [aDecoder decodeObjectForKey:NSStringFromSelector(@selector(accessibilityValue))];
+    }
+    
+    return self;
 }
 
 @end

--- a/Classes/BITFeedbackListViewCell.m
+++ b/Classes/BITFeedbackListViewCell.m
@@ -107,11 +107,11 @@
     _labelTitle = [[UILabel alloc] init];
     _labelTitle.font = [UIFont systemFontOfSize:TITLE_FONTSIZE];
     
-    _labelText = [[BITAttributedLabel alloc] init];
+    _labelText = [[BITAttributedLabel alloc] initWithFrame:CGRectZero];
     _labelText.font = [UIFont systemFontOfSize:TEXT_FONTSIZE];
     _labelText.numberOfLines = 0;
     _labelText.textAlignment = NSTextAlignmentLeft;
-    _labelText.dataDetectorTypes = UIDataDetectorTypeAll;
+    _labelText.enabledTextCheckingTypes = UIDataDetectorTypeAll;
     
     _attachmentViews = [NSMutableArray new];
     [self registerObservers];


### PR DESCRIPTION
Bug:
Long Feedback in FeedbackViewController is truncated. Happens for any language but was reported by a customer from China as chars in simplified Chinese are cut of earlier (fewer glyphs).
Happens on iOS9, not on iOS 7. (https://support.hockeyapp.net/discussions/problems/58559-content-in-feedback-is-truncated-in-ios9)

Fix:
Update BITAttributedLabel to code from TTTAttributedLabel 1.13.4 (can't use TTTAttributedLabel 2.0.0 as it requires iOS 8)

@lumaxis @chrwend 
Feel free to test and let me know if it's ok to merge =)
