### PR TITLE
Feature/fix multithreading issue in bitchannel

### DIFF
--- a/Classes/BITAuthenticator.m
+++ b/Classes/BITAuthenticator.m
@@ -960,6 +960,9 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
   } else {
     [defaults setObject:lastAuthenticatedVersion
                  forKey:kBITAuthenticatorLastAuthenticatedVersionKey];
+    if(bit_isPreiOS8Environment()) {
+      [defaults synchronize];
+    }
   }
 }
 

--- a/Classes/BITAuthenticator.m
+++ b/Classes/BITAuthenticator.m
@@ -960,7 +960,6 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
   } else {
     [defaults setObject:lastAuthenticatedVersion
                  forKey:kBITAuthenticatorLastAuthenticatedVersionKey];
-    [defaults synchronize];
   }
 }
 

--- a/Classes/BITCrashManager.m
+++ b/Classes/BITCrashManager.m
@@ -522,6 +522,10 @@ static void uncaught_cxx_exception_handler(const BITCrashUncaughtCXXExceptionInf
                                                                                              if (!_didLogLowMemoryWarning) {
                                                                                                [[NSUserDefaults standardUserDefaults] setBool:YES forKey:kBITAppDidReceiveLowMemoryNotification];
                                                                                                _didLogLowMemoryWarning = YES;
+                                                                                               if(bit_isPreiOS8Environment()) {
+                                                                                                 // calling synchronize in pre-iOS 8 takes longer to sync than in iOS 8+, calling synchronize explicitly.
+                                                                                                 [[NSUserDefaults standardUserDefaults] synchronize];
+                                                                                               }
                                                                                              }
                                                                                            }];
   }
@@ -547,7 +551,10 @@ static void uncaught_cxx_exception_handler(const BITCrashUncaughtCXXExceptionInf
 - (void)leavingAppSafely {
   if (self.isAppNotTerminatingCleanlyDetectionEnabled) {
     [[NSUserDefaults standardUserDefaults] setBool:YES forKey:kBITAppWentIntoBackgroundSafely];
-    [[NSUserDefaults standardUserDefaults] synchronize];
+    if(bit_isPreiOS8Environment()) {
+      // calling synchronize in pre-iOS 8 takes longer to sync than in iOS 8+, calling synchronize explicitly.
+      [[NSUserDefaults standardUserDefaults] synchronize];
+    }
   }
 }
 
@@ -578,6 +585,10 @@ static void uncaught_cxx_exception_handler(const BITCrashUncaughtCXXExceptionInf
                              ];
 
       [[NSUserDefaults standardUserDefaults] setObject:uuidString forKey:kBITAppUUIDs];
+      if(bit_isPreiOS8Environment()) {
+        // calling synchronize in pre-iOS 8 takes longer to sync than in iOS 8+, calling synchronize explicitly.
+        [[NSUserDefaults standardUserDefaults] synchronize];
+      }
     });
   }
 }
@@ -820,6 +831,7 @@ static void uncaught_cxx_exception_handler(const BITCrashUncaughtCXXExceptionInf
     case BITCrashManagerUserInputAlwaysSend:
       _crashManagerStatus = BITCrashManagerStatusAutoSend;
       [[NSUserDefaults standardUserDefaults] setInteger:_crashManagerStatus forKey:kBITCrashManagerStatus];
+
       if ([self.delegate respondsToSelector:@selector(crashManagerWillSendCrashReportsAlways:)]) {
         [self.delegate crashManagerWillSendCrashReportsAlways:self];
       }
@@ -1273,6 +1285,11 @@ static void uncaught_cxx_exception_handler(const BITCrashUncaughtCXXExceptionInf
 #endif
   
   [[NSUserDefaults standardUserDefaults] setBool:NO forKey:kBITAppDidReceiveLowMemoryNotification];
+  
+  if(bit_isPreiOS8Environment()) {
+    // calling synchronize in pre-iOS 8 takes longer to sync than in iOS 8+, calling synchronize explicitly.
+    [[NSUserDefaults standardUserDefaults] synchronize];
+  }
   
   [self triggerDelayedProcessing];
   BITHockeyLogVerbose(@"VERBOSE: CrashManager startManager has finished.");

--- a/Classes/BITCrashManager.m
+++ b/Classes/BITCrashManager.m
@@ -521,7 +521,6 @@ static void uncaught_cxx_exception_handler(const BITCrashUncaughtCXXExceptionInf
                                                                                              // we only need to log this once
                                                                                              if (!_didLogLowMemoryWarning) {
                                                                                                [[NSUserDefaults standardUserDefaults] setBool:YES forKey:kBITAppDidReceiveLowMemoryNotification];
-                                                                                               [[NSUserDefaults standardUserDefaults] synchronize];
                                                                                                _didLogLowMemoryWarning = YES;
                                                                                              }
                                                                                            }];
@@ -548,7 +547,6 @@ static void uncaught_cxx_exception_handler(const BITCrashUncaughtCXXExceptionInf
 - (void)leavingAppSafely {
   if (self.isAppNotTerminatingCleanlyDetectionEnabled) {
     [[NSUserDefaults standardUserDefaults] setBool:YES forKey:kBITAppWentIntoBackgroundSafely];
-    [[NSUserDefaults standardUserDefaults] synchronize];
   }
 }
 
@@ -1274,7 +1272,6 @@ static void uncaught_cxx_exception_handler(const BITCrashUncaughtCXXExceptionInf
 #endif
   
   [[NSUserDefaults standardUserDefaults] setBool:NO forKey:kBITAppDidReceiveLowMemoryNotification];
-  [[NSUserDefaults standardUserDefaults] synchronize];
   
   [self triggerDelayedProcessing];
   BITHockeyLogVerbose(@"VERBOSE: CrashManager startManager has finished.");

--- a/Classes/BITCrashManager.m
+++ b/Classes/BITCrashManager.m
@@ -547,6 +547,7 @@ static void uncaught_cxx_exception_handler(const BITCrashUncaughtCXXExceptionInf
 - (void)leavingAppSafely {
   if (self.isAppNotTerminatingCleanlyDetectionEnabled) {
     [[NSUserDefaults standardUserDefaults] setBool:YES forKey:kBITAppWentIntoBackgroundSafely];
+    [[NSUserDefaults standardUserDefaults] synchronize];
   }
 }
 

--- a/Classes/BITMetricsManager.m
+++ b/Classes/BITMetricsManager.m
@@ -118,6 +118,10 @@ static NSString *const BITMetricsURLPathString = @"v2/track";
 
 - (void)updateDidEnterBackgroundTime {
   [self.userDefaults setDouble:[[NSDate date] timeIntervalSince1970] forKey:kBITApplicationDidEnterBackgroundTime];
+  if(bit_isPreiOS8Environment()) {
+    // calling synchronize in pre-iOS 8 takes longer to sync than in iOS 8+, calling synchronize explicitly.
+    [self.userDefaults synchronize];
+  }
 }
 
 - (void)startNewSessionIfNeeded {
@@ -126,6 +130,10 @@ static NSString *const BITMetricsURLPathString = @"v2/track";
   if(appDidEnterBackgroundTime < 0) {
     appDidEnterBackgroundTime = 0;
     [self.userDefaults setDouble:0 forKey:kBITApplicationDidEnterBackgroundTime];
+    if(bit_isPreiOS8Environment()) {
+      // calling synchronize in pre-iOS 8 takes longer to sync than in iOS 8+, calling synchronize explicitly.
+      [self.userDefaults synchronize];
+    }
   }
   double timeSinceLastBackground = [[NSDate date] timeIntervalSince1970] - appDidEnterBackgroundTime;
   if (timeSinceLastBackground > self.appBackgroundTimeBeforeSessionExpires) {
@@ -149,6 +157,10 @@ static NSString *const BITMetricsURLPathString = @"v2/track";
   if (![self.userDefaults boolForKey:kBITApplicationWasLaunched]) {
     session.isFirst = @"true";
     [self.userDefaults setBool:YES forKey:kBITApplicationWasLaunched];
+    if(bit_isPreiOS8Environment()) {
+      // calling synchronize in pre-iOS 8 takes longer to sync than in iOS 8+, calling synchronize explicitly.
+      [self.userDefaults synchronize];
+    }
   } else {
     session.isFirst = @"false";
   }

--- a/Classes/BITMetricsManager.m
+++ b/Classes/BITMetricsManager.m
@@ -118,7 +118,6 @@ static NSString *const BITMetricsURLPathString = @"v2/track";
 
 - (void)updateDidEnterBackgroundTime {
   [self.userDefaults setDouble:[[NSDate date] timeIntervalSince1970] forKey:kBITApplicationDidEnterBackgroundTime];
-  [self.userDefaults synchronize];
 }
 
 - (void)startNewSessionIfNeeded {
@@ -150,7 +149,6 @@ static NSString *const BITMetricsURLPathString = @"v2/track";
   if (![self.userDefaults boolForKey:kBITApplicationWasLaunched]) {
     session.isFirst = @"true";
     [self.userDefaults setBool:YES forKey:kBITApplicationWasLaunched];
-    [self.userDefaults synchronize];
   } else {
     session.isFirst = @"false";
   }

--- a/Classes/BITMetricsManager.m
+++ b/Classes/BITMetricsManager.m
@@ -122,15 +122,12 @@ static NSString *const BITMetricsURLPathString = @"v2/track";
 }
 
 - (void)startNewSessionIfNeeded {
-  if (self.appBackgroundTimeBeforeSessionExpires == 0) {
-    __weak typeof(self) weakSelf = self;
-    dispatch_async(_metricsEventQueue, ^{
-      typeof(self) strongSelf = weakSelf;
-      [strongSelf startNewSessionWithId:bit_UUID()];
-    });
-  }
-
   double appDidEnterBackgroundTime = [self.userDefaults doubleForKey:kBITApplicationDidEnterBackgroundTime];
+  // Add safeguard in case this returns a negative value
+  if(appDidEnterBackgroundTime < 0) {
+    appDidEnterBackgroundTime = 0;
+    [self.userDefaults setDouble:0 forKey:kBITApplicationDidEnterBackgroundTime];
+  }
   double timeSinceLastBackground = [[NSDate date] timeIntervalSince1970] - appDidEnterBackgroundTime;
   if (timeSinceLastBackground > self.appBackgroundTimeBeforeSessionExpires) {
     [self startNewSessionWithId:bit_UUID()];

--- a/Classes/BITStoreUpdateManager.m
+++ b/Classes/BITStoreUpdateManager.m
@@ -165,6 +165,11 @@
         [self.userDefaults removeObjectForKey:kBITStoreUpdateLastStoreVersion];
         versionString = nil;
       }
+      
+      if(bit_isPreiOS8Environment()) {
+        // calling synchronize in pre-iOS 8 takes longer to sync than in iOS 8+, calling synchronize explicitly.
+        [self.userDefaults synchronize];
+      }
     }
   }
   

--- a/Classes/BITStoreUpdateManager.m
+++ b/Classes/BITStoreUpdateManager.m
@@ -165,8 +165,6 @@
         [self.userDefaults removeObjectForKey:kBITStoreUpdateLastStoreVersion];
         versionString = nil;
       }
-
-      [self.userDefaults synchronize];
     }
   }
   

--- a/Support/HockeySDKTests/BITMetricsManagerTests.m
+++ b/Support/HockeySDKTests/BITMetricsManagerTests.m
@@ -21,12 +21,12 @@
 @implementation BITMetricsManagerTests
 
 - (void)setUp {
-    [super setUp];
-    // Put setup code here. This method is called before the invocation of each test method in the class.
+  [super setUp];
+  // Put setup code here. This method is called before the invocation of each test method in the class.
 }
 
 - (void)tearDown {
-    [super tearDown];
+  [super tearDown];
 }
 
 - (void)testMetricsManagerGetsInstantiated {
@@ -92,9 +92,9 @@
 #pragma clang diagnostic pop
   
   OCMExpect([mockChannel enqueueTelemetryItem:[OCMArg checkWithBlock:^BOOL(NSObject *value)
-                                             {
-                                               return [value isKindOfClass:[BITSessionStateData class]];
-                                             }]]);
+                                               {
+                                                 return [value isKindOfClass:[BITSessionStateData class]];
+                                               }]]);
   [self.sut trackSessionWithState:BITSessionState_start];
   OCMVerifyAll(mockChannel);
 }
@@ -109,7 +109,7 @@
 #pragma clang diagnostic ignored "-Wnonnull"
   self.sut = [[BITMetricsManager alloc] initWithChannel:nil telemetryContext:mockContext persistence:nil userDefaults:testUserDefaults];
 #pragma clang diagnostic pop
-
+  
   NSString *testSessionId = @"sessionId";
   
   OCMExpect([mockContext setSessionId:testSessionId]);
@@ -119,5 +119,88 @@
   [self.sut startNewSessionWithId:testSessionId];
   OCMVerifyAll(mockContext);
 }
+
+- (void)testNewSessionCreated {
+  NSUserDefaults *testUserDefaults = [NSUserDefaults new];
+  BITTelemetryContext *context = [BITTelemetryContext new];
+  
+  BITChannel *channel = [BITChannel new];
+  id mockChannel = OCMPartialMock(channel);
+  
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+  self.sut = [[BITMetricsManager alloc] initWithChannel:mockChannel telemetryContext:context persistence:nil userDefaults:testUserDefaults];
+#pragma clang diagnostic pop
+
+  int sessionStartCount = 0;
+  int sessionNotRenewedCount = 0;
+  
+  for(int i = 0; i < 100; i++) {
+    double randomOffset = (i%2 == 0) ? arc4random_uniform(1000 - 20 + 1) + 20 : arc4random_uniform(19 - 0 + 1) + 0;
+    double backgroundtime = [[NSDate date] timeIntervalSince1970] - randomOffset;
+    [testUserDefaults setDouble:backgroundtime forKey:@"BITApplicationDidEnterBackgroundTime"];
+    
+    [self.sut startNewSessionIfNeeded];
+    
+    NSLog(@"Test iteration %i", i);
+
+    
+    if(randomOffset >= 20.0) {
+      NSLog(@"Calling OCMVerify for %f", randomOffset);
+      OCMVerify([mockChannel enqueueTelemetryItem:anything()]);
+      sessionStartCount +=1;
+    }
+    else {
+      NSLog(@"Calling OCMReject for %f", randomOffset);
+      // we cant OCMReject for the mockChannel as it will fail because enqueueTelemetryItem has been invoked before for all
+      // randomOffset >= 20.
+      sessionNotRenewedCount +=1;
+    }
+  }
+  
+  // Ac we can't use OCMReject, at least verify the counts of the cases.
+  XCTAssertEqual(sessionStartCount, 50);
+  XCTAssertEqual(sessionNotRenewedCount, 50);
+}
+
+- (void)testNewSessionNeverCreated {
+  NSUserDefaults *testUserDefaults = [NSUserDefaults new];
+  BITTelemetryContext *context = [BITTelemetryContext new];
+  
+  BITChannel *channel = [BITChannel new];
+  id mockChannel = OCMPartialMock(channel);
+  
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+  self.sut = [[BITMetricsManager alloc] initWithChannel:mockChannel telemetryContext:context persistence:nil userDefaults:testUserDefaults];
+#pragma clang diagnostic pop
+  
+  int sessionStartCount = 0;
+  int sessionNotRenewedCount = 0;
+  for(int i = 0; i < 100; i++) {
+    double randomOffset = (i%2 == 0) ? arc4random_uniform(19 - 0 + 1) + 0 : arc4random_uniform(19 - 0 + 1) + 0;
+    double backgroundtime = [[NSDate date] timeIntervalSince1970] - randomOffset;
+    [testUserDefaults setDouble:backgroundtime forKey:@"BITApplicationDidEnterBackgroundTime"];
+    
+    [self.sut startNewSessionIfNeeded];
+    
+    NSLog(@"Test iteration %i", i);
+    
+    if(randomOffset >= 20.0) {
+      NSLog(@"Calling OCMVerify for %f", randomOffset);
+      OCMVerify([mockChannel enqueueTelemetryItem:anything()]);
+      sessionStartCount +=1;
+    }
+    else {
+      NSLog(@"Calling OCMReject for %f", randomOffset);
+      OCMReject([mockChannel enqueueTelemetryItem:anything()]);
+      sessionNotRenewedCount +=1;
+    }
+  }
+  
+  XCTAssertEqual(sessionStartCount, 0);
+  XCTAssertEqual(sessionNotRenewedCount, 100);
+}
+
 
 @end


### PR DESCRIPTION
- removed calls to `synchronize` for NSUserDefault as they aren't recommended (and async anyway)
- added a safeguard in case we have a negative appBackgroundtime
- added two unit tests for new session creation
