### PR TITLE
Rename properties of BITCrashMetaData to avoid namespace collisions.

### DIFF
--- a/Classes/BITCrashManager.m
+++ b/Classes/BITCrashManager.m
@@ -377,10 +377,10 @@ static void uncaught_cxx_exception_handler(const BITCrashUncaughtCXXExceptionInf
 
 - (void)persistUserProvidedMetaData:(BITCrashMetaData *)userProvidedMetaData {
   if (!userProvidedMetaData) return;
-  
-  if (userProvidedMetaData.userDescription && [userProvidedMetaData.userDescription length] > 0) {
+
+  if (userProvidedMetaData.userProvidedDescription && [userProvidedMetaData.userProvidedDescription length] > 0) {
     NSError *error;
-    [userProvidedMetaData.userDescription writeToFile:[NSString stringWithFormat:@"%@.desc", [_crashesDir stringByAppendingPathComponent: _lastCrashFilename]] atomically:YES encoding:NSUTF8StringEncoding error:&error];
+    [userProvidedMetaData.userProvidedDescription writeToFile:[NSString stringWithFormat:@"%@.desc", [_crashesDir stringByAppendingPathComponent: _lastCrashFilename]] atomically:YES encoding:NSUTF8StringEncoding error:&error];
   }
   
   if (userProvidedMetaData.userName && [userProvidedMetaData.userName length] > 0) {

--- a/Classes/BITCrashMetaData.h
+++ b/Classes/BITCrashMetaData.h
@@ -37,7 +37,7 @@
 /**
  *  User provided description that should be attached to the crash report as plain text
  */
-@property (nonatomic, copy) NSString *userDescription;
+@property (nonatomic, copy) NSString *userProvidedDescription;
 
 /**
  *  User name that should be attached to the crash report

--- a/Support/HockeySDKTests/BITCrashManagerTests.m
+++ b/Support/HockeySDKTests/BITCrashManagerTests.m
@@ -103,7 +103,7 @@ static NSString *const kBITCrashMetaAttachment = @"BITCrashMetaAttachment";
   [_sut setLastCrashFilename:tempCrashName];
   
   BITCrashMetaData *metaData = [BITCrashMetaData new];
-  [metaData setUserDescription:@"Test string"];
+  [metaData setUserProvidedDescription:@"Test string"];
   [_sut persistUserProvidedMetaData:metaData];
   
   NSError *error;


### PR DESCRIPTION
We've had reports that Apple's automatic code review tool mistakenly thinks the `userDescription` property is a private api usage. It's definitely not using private API, nonetheless we have to do something about the naming collision.
I'd love to not make this a breaking change but annotating the old properies with @deprecated won't help, so just renaming them.