### PR TITLE
Fixed static analysis warnings. 

### DIFF
--- a/Classes/BITFeedbackListViewController.m
+++ b/Classes/BITFeedbackListViewController.m
@@ -1011,7 +1011,8 @@
     }
   }
   
-  return nil;
+  BITHockeyLogError(@"Error: No QLPreviewItem found at index.");
+  abort();
 }
 
 - (void)previewController:(QLPreviewController *)controller updateAttachment:(BITFeedbackMessageAttachment *)attachment data:( NSData *)data {

--- a/Classes/BITHockeyHelper.m
+++ b/Classes/BITHockeyHelper.m
@@ -650,6 +650,11 @@ NSString *bit_validAppIconStringFromIcons(NSBundle *resourceBundle, NSArray *ico
         iconPath = [resourceBundle pathForResource:iconFilename ofType:icon.pathExtension];
       }
       
+      if (!iconPath) {
+        BITHockeyLogError(@"Error: No icon found for the given name.");
+        abort();
+      }
+      
       NSData *imgData = [[NSData alloc] initWithContentsOfFile:iconPath];
       
       UIImage *iconImage = [[UIImage alloc] initWithData:imgData];

--- a/Classes/BITUpdateViewController.m
+++ b/Classes/BITUpdateViewController.m
@@ -494,9 +494,9 @@
   if ([_cells count] > (NSUInteger)indexPath.row) {
     return [_cells objectAtIndex:indexPath.row];
   } else {
-    BITHockeyLogWarning(@"Warning: cells_ and indexPath do not match? forgot calling redrawTableView?");
+    BITHockeyLogError(@"Error: cells_ and indexPath do not match? forgot calling redrawTableView?");
+    abort();
   }
-  return nil;
 }
 
 


### PR DESCRIPTION
There were a couple static analysis warnings in the latest build. While these should always be fixed, it's extra important for Carthage users because they get logged when building.

I'm not sure what the general stance is on reporting errors that HockeySDK consumers can cause, but in each of these cases it seems that the app cannot gracefully recover. Adding calls to ```abort()``` fixes the static analysis warnings, and I chose to add some errors to explain why the SDK would abort.