### PR TITLE
Check if update alert should be shown with update manager delegate

### DIFF
--- a/Classes/BITUpdateManager.m
+++ b/Classes/BITUpdateManager.m
@@ -552,7 +552,12 @@ typedef NS_ENUM(NSInteger, BITUpdateAlertViewTag) {
 - (void)showCheckForUpdateAlert {
   if (self.appEnvironment != BITEnvironmentOther) return;
   if ([self isUpdateManagerDisabled]) return;
-  
+
+  if ([self.delegate respondsToSelector:@selector(shouldDisplayUpdateAlertForUpdateManager:forShortVersion:forVersion:)] &&
+      ![self.delegate shouldDisplayUpdateAlertForUpdateManager:self forShortVersion:[self.newestAppVersion shortVersion] forVersion:[self.newestAppVersion version]]) {
+    return;
+  }
+
   if (!_updateAlertShowing) {
     NSString *title = BITHockeyLocalizedString(@"UpdateAvailable");
     NSString *message = [NSString stringWithFormat:BITHockeyLocalizedString(@"UpdateAlertMandatoryTextWithAppVersion"), [self.newestAppVersion nameAndVersionString]];

--- a/Classes/BITUpdateManagerDelegate.h
+++ b/Classes/BITUpdateManagerDelegate.h
@@ -39,6 +39,29 @@
 
 @optional
 
+///-----------------------------------------------------------------------------
+/// @name Update
+///-----------------------------------------------------------------------------
+
+/**
+ Return if update alert should be shown
+
+ If you want to display your own user interface when there is an update available,
+ implement this method, present your user interface and return _NO_. In this case
+ it is your responsibility to call `BITUpdateManager showUpdateView`
+
+ Note: This delegate will be invoked on startup and every time the app becomes
+ active again!
+
+ When returning _YES_ the default blocking UI will be shown.
+
+ When running the app from the App Store, this delegate is ignored.
+
+ @param updateManager The `BITUpdateManager` instance invoking this delegate
+ @param shortVersion The latest available version
+ @param version The latest available version
+ */
+- (BOOL)shouldDisplayUpdateAlertForUpdateManager:(BITUpdateManager *)updateManager forShortVersion:(NSString *)shortVersion forVersion:(NSString *)version;
 
 ///-----------------------------------------------------------------------------
 /// @name Expiry


### PR DESCRIPTION
I've added a method `shouldDisplayUpdateAlertForUpdateManager ` in the `UpdateManagerDelegate`. This method is called before the blocking alert prompting to update is shown, and can be used to show a custom UI instead of the blocking alert. 