### PR TITLE
Added support for logging exceptions

### DIFF
--- a/Classes/BITCrashManager.h
+++ b/Classes/BITCrashManager.h
@@ -438,4 +438,10 @@ typedef NS_ENUM(NSUInteger, BITCrashManagerUserInput) {
  */
 - (void)generateTestCrash;
 
+/**
+ * Generates a crash report as if the app had crashed at the current execution point
+ * with the provided exception.
+ */
+- (void)logException:(NSException *)exception;
+
 @end


### PR DESCRIPTION
This uses the plcrashreporter methods that were added in the last year or so in order to support logging an exception and stacktrace without crashing.