### PR TITLE
Don't build the test target during the "Run" action of the framework.

### DIFF
--- a/Support/HockeySDK.xcodeproj/xcshareddata/xcschemes/HockeySDK Framework.xcscheme
+++ b/Support/HockeySDK.xcodeproj/xcshareddata/xcschemes/HockeySDK Framework.xcscheme
@@ -22,7 +22,7 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
             buildForAnalyzing = "YES">


### PR DESCRIPTION
Not building the test target during the "Run" action of the framework gives us the possibility to easily build the framework via Carthage with any available configuration.

You currently get build errors if you try to build with the "ReleaseCrashOnly" configuration due to missing classes in the test target for this config.

After this change you for example can simply use the following command to build the framework for the "crash only" configuration:
`carthage build --configuration ReleaseCrashOnly`


See also: https://github.com/bitstadium/HockeySDK-iOS/issues/372