### PR TITLE
Fix additional UINavigationControllers

### DIFF
--- a/Classes/BITFeedbackComposeViewController.m
+++ b/Classes/BITFeedbackComposeViewController.m
@@ -662,7 +662,7 @@
     BITFeedbackMessageAttachment *attachment = self.imageAttachments[self.selectedAttachmentIndex];
     BITImageAnnotationViewController *annotationEditor = [[BITImageAnnotationViewController alloc ] init];
     annotationEditor.delegate = self;
-    UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:annotationEditor];
+    UINavigationController *navController = [self.manager customNavigationControllerWithRootViewController:annotationEditor presentationStyle:UIModalPresentationFullScreen];
     annotationEditor.image = attachment.imageRepresentation;
     [self presentViewController:navController animated:YES completion:nil];
   }

--- a/Classes/BITFeedbackComposeViewController.m
+++ b/Classes/BITFeedbackComposeViewController.m
@@ -499,6 +499,7 @@
   pickerController.sourceType = UIImagePickerControllerSourceTypePhotoLibrary;
   pickerController.delegate = self;
   pickerController.editing = NO;
+  pickerController.navigationBar.barStyle = self.manager.barStyle;
   [self presentViewController:pickerController animated:YES completion:nil];
 }
 

--- a/Classes/BITHockeyBaseManager.m
+++ b/Classes/BITHockeyBaseManager.m
@@ -190,7 +190,7 @@
       }
     }
   }
-  navController.modalPresentationStyle = self.modalPresentationStyle;
+  navController.modalPresentationStyle = modalPresentationStyle;
   
   return navController;
 }


### PR DESCRIPTION
We recently wanted to use the feedback features of the iOS SDK, but noticed a couple of visual bugs in how it was working. We need the status bar to use the .LightContent style, which is configured by the UINavigationBar.barStyle

I'm concerned that the second commit in this series may cause regressions for customers who are setting the modal presentation style. Do you have any sense of how much this gets used?

Also, for the third commit, more could be done to set up the UIImagePickerController, but this is all we needed so I didn't do the additional work to test other scenarios.