### PR TITLE
Fix bug: feedback attachment sourceURL not set from response

### DIFF
--- a/Classes/BITFeedbackManager.m
+++ b/Classes/BITFeedbackManager.m
@@ -780,6 +780,7 @@ typedef void (^BITLatestImageFetchCompletionBlock)(UIImage *_Nonnull latestImage
                 int attachmentIndex = 0;
                 for (BITFeedbackMessageAttachment *attachment in matchingSendInProgressOrInConflictMessage.attachments) {
                   attachment.identifier = feedbackAttachments[attachmentIndex][@"id"];
+                  attachment.sourceURL = feedbackAttachments[attachmentIndex][@"url"];
                   attachmentIndex++;
                 }
               }

--- a/Classes/BITFeedbackMessageAttachment.m
+++ b/Classes/BITFeedbackMessageAttachment.m
@@ -209,6 +209,13 @@
 
 #pragma mark - Persistence Helpers
 
+- (void)setFilename:(NSString *)filename {
+  if (filename) {
+    filename = [_cachePath stringByAppendingPathComponent:[filename lastPathComponent]];
+  }
+  _filename = filename;
+}
+
 - (NSString *)possibleFilename {
   if (_tempFilename) {
     return _tempFilename;


### PR DESCRIPTION
If user sends a feedback from the app with attachments, the attachment URLs returned in the response were not added to the attachment object, and so they were not stored in the devices storage. On the next app start the attachments would not download from the server, because the sourceURL is nil.