### PR TITLE
Undo changes related to Xamarin SDK fixes

### DIFF
--- a/Classes/BITCrashManager.m
+++ b/Classes/BITCrashManager.m
@@ -1154,18 +1154,10 @@ static void uncaught_cxx_exception_handler(const BITCrashUncaughtCXXExceptionInf
   }
 }
 
-- (void)startManagerInXamarinEnvironment {
-  [self startManagerInSdkEnvironment:BITSdkEnvironmentXamarin];
-}
-
-- (void)startManager {
-  [self startManagerInSdkEnvironment:BITSdkEnvironmentNative];
-}
-
 /**
  *	 Main startup sequence initializing PLCrashReporter if it wasn't disabled
  */
-- (void)startManagerInSdkEnvironment:(BITSdkEnvironment)sdkEnvironment {
+- (void)startManager {
   if (_crashManagerStatus == BITCrashManagerStatusDisabled) return;
   
   [self registerObservers];
@@ -1187,21 +1179,8 @@ static void uncaught_cxx_exception_handler(const BITCrashUncaughtCXXExceptionInf
         symbolicationStrategy = PLCrashReporterSymbolicationStrategyAll;
       }
       
-      BITPLCrashReporterConfig *config;
-      
-      switch (sdkEnvironment) {
-        case BITSdkEnvironmentXamarin:
-          config = [[BITPLCrashReporterConfig alloc] initWithSignalHandlerType: signalHandlerType
-                                                         symbolicationStrategy: symbolicationStrategy
-                                        shouldRegisterUncaughtExceptionHandler:NO];
-
-          break;
-        default:
-          config = [[BITPLCrashReporterConfig alloc] initWithSignalHandlerType: signalHandlerType
-                                                         symbolicationStrategy: symbolicationStrategy];
-          break;
-      }
-      
+      BITPLCrashReporterConfig *config = [[BITPLCrashReporterConfig alloc] initWithSignalHandlerType: signalHandlerType
+                                                                               symbolicationStrategy: symbolicationStrategy];
       self.plCrashReporter = [[BITPLCrashReporter alloc] initWithConfiguration: config];
       
       // Check if we previously crashed
@@ -1263,11 +1242,9 @@ static void uncaught_cxx_exception_handler(const BITCrashUncaughtCXXExceptionInf
         } else {
           
           // If we're running in a Xamarin Environment, the exception handler will be the one by the xamarin runtime, not ours.
-          // So only make sure we're logging the error in a non-xamarin environment.
-          if(sdkEnvironment != BITSdkEnvironmentXamarin) {
-            // this should never happen, theoretically only if NSSetUncaugtExceptionHandler() has some internal issues
-            BITHockeyLogError(@"[HockeySDK] ERROR: Exception handler could not be set. Make sure there is no other exception handler set up!");
-          }
+          // In other cases, this should never happen, theoretically only if NSSetUncaugtExceptionHandler() has some internal issues
+          BITHockeyLogError(@"[HockeySDK] ERROR: Exception handler could not be set. Make sure there is no other exception handler set up!");
+          BITHockeyLogError(@"[HockeySDK] ERROR: If you are using the HockeySDK-Xamarin, this is expected behavior and you can ignore this message");
         }
         
         // Add the C++ uncaught exception handler, which is currently not handled by PLCrashReporter internally

--- a/Classes/BITCrashManagerPrivate.h
+++ b/Classes/BITCrashManagerPrivate.h
@@ -85,8 +85,6 @@
 
 - (instancetype)initWithAppIdentifier:(NSString *)appIdentifier appEnvironment:(BITEnvironment)environment hockeyAppClient:(BITHockeyAppClient *)hockeyAppClient NS_DESIGNATED_INITIALIZER;
 
-- (void)startManagerInXamarinEnvironment;
-
 - (void)cleanCrashReports;
 
 - (NSString *)userIDForCrashReport;

--- a/Classes/BITHockeyManager.h
+++ b/Classes/BITHockeyManager.h
@@ -191,19 +191,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)startManager;
 
-/**
- Starts the manager and runs all modules from a Xamarin environment. This is intended to be used by the HockeySDK-Xamarin.
- We now need to make a difference as BITCrashManager needs to setup PLCrashReporter differently for Xamarin apps.
- 
- @warning Do not use this API from within a native iOS app.
- 
- Call this after configuring the manager and setting up all modules.
- 
- @see configureWithIdentifier:delegate:
- @see configureWithBetaIdentifier:liveIdentifier:delegate:
- */
-- (void)startManagerInXamarinEnvironment;
-
 #pragma mark - Public Properties
 
 ///-----------------------------------------------------------------------------

--- a/Classes/BITHockeyManager.m
+++ b/Classes/BITHockeyManager.m
@@ -220,15 +220,6 @@ bitstadium_info_t bitstadium_library_info __attribute__((section("__TEXT,__bit_h
 }
 
 - (void)startManager {
-  [self startManagerWithEnvironment:BITSdkEnvironmentNative];
-}
-
-- (void)startManagerInXamarinEnvironment {
-  [self startManagerWithEnvironment:BITSdkEnvironmentXamarin];
-  BITHockeyLogVerbose(@"Started the BITHockeyManager with Xamarin Environment.");
-}
-
-- (void)startManagerWithEnvironment:(BITSdkEnvironment)sdkEnvironment {
   if (!_validAppIdentifier) return;
   if (_startManagerIsInvoked) {
     BITHockeyLogWarning(@"[HockeySDK] Warning: startManager should only be invoked once! This call is ignored.");
@@ -262,15 +253,7 @@ bitstadium_info_t bitstadium_library_info __attribute__((section("__TEXT,__bit_h
     }
 #endif
 
-    // Start BITCrashManager with the environment flag to make sure we don't break NSException reporting for Xamarin.
-    switch (sdkEnvironment) {
-      case BITSdkEnvironmentXamarin:
-        [_crashManager startManagerInXamarinEnvironment];
-        break;
-      default:
-        [_crashManager startManager];
-        break;
-    }
+    [_crashManager startManager];
   }
 #endif /* HOCKEYSDK_FEATURE_CRASH_REPORTER */
   

--- a/Classes/HockeySDKEnums.h
+++ b/Classes/HockeySDKEnums.h
@@ -184,18 +184,4 @@ typedef NS_ENUM(NSInteger, BITHockeyErrorReason) {
   BITHockeyErrorUnknown
 };
 
-/**
- *  SDK Environment
- */
-typedef NS_ENUM (NSUInteger, BITSdkEnvironment) {
-  /**
-   *  A regular native iOS environment
-   */
-  BITSdkEnvironmentNative = 0,
-  /**
-   *  A xamarin environment
-   */
-  BITSdkEnvironmentXamarin = 1
-};
-
 #endif /* HockeySDK_HockeyEnums_h */


### PR DESCRIPTION
This removes previous changes that were made to fix an issue in the HockeySDK-Xamarin, which introduced a regression. This regression only affects the HockeySDK-Xamarin and not the native SDK. This PR just cleans up the changes.