### PR TITLE
Fix BITAuthenticator state after cleanup

### DIFF
--- a/Classes/BITAuthenticator.m
+++ b/Classes/BITAuthenticator.m
@@ -776,6 +776,8 @@ static unsigned char kBITPNGEndChunk[4] = {0x49, 0x45, 0x4e, 0x44};
   [self removeKeyFromKeychain:kBITAuthenticatorUUIDKey];
   [self removeKeyFromKeychain:kBITAuthenticatorUserEmailKey];
   [self setLastAuthenticatedVersion:nil];
+  self.identified = NO;
+  self.validated = NO;
   
   //cleanup values stored from 3.5 Beta1..Beta3
   [self removeKeyFromKeychain:kBITAuthenticatorAuthTokenKey];

--- a/Support/HockeySDKTests/BITAuthenticatorTests.m
+++ b/Support/HockeySDKTests/BITAuthenticatorTests.m
@@ -90,11 +90,15 @@ static void *kInstallationIdentification = &kInstallationIdentification;
 
 - (void) testThatCleanupWorks {
   self.sut.lastAuthenticatedVersion = @"1.2";
+  self.sut.identified = YES;
+  self.sut.validated = YES;
   
   [self.sut cleanupInternalStorage];
   
   assertThat(self.sut.lastAuthenticatedVersion, equalTo(nil));
   assertThat(self.sut.installationIdentifier, equalTo(nil));
+  assertThatBool(self.sut.isIdentified, isFalse());
+  assertThatBool(self.sut.isValidated, isFalse());
 }
 
 #pragma mark - Initial defaults


### PR DESCRIPTION
## Issue
Dialog with following error is shown in infinite loop (appears again and again after close):
`[HockeySDK] -[BITAuthenticator validate]_block_invoke/243 Validation failed with error: Error Domain=BITAuthenticatorErrorDomain Code=6 "Make sure to identify the installation first" UserInfo={NSLocalizedDescription=Make sure to identify the installation first}`

## Reproduction
Code:
```objc
- (void)authenticateDevice {
  BITAuthenticator *authenticator = BITHockeyManager.sharedHockeyManager.authenticator;
  [authenticator cleanupInternalStorage];
  authenticator.identificationType = BITAuthenticatorIdentificationTypeDevice;
  authenticator.restrictApplicationUsage = YES;
  [authenticator authenticateInstallation];
}
```
Steps:
1. Be already autentificated with same `identificationType`
2. Call `cleanupInternalStorage`
3. Call `authenticateInstallation`
