### PR TITLE
Added reporting of non-fatal conditions

### DIFF
--- a/Classes/BITCrashManager.h
+++ b/Classes/BITCrashManager.h
@@ -407,6 +407,16 @@ typedef NS_ENUM(NSUInteger, BITCrashManagerUserInput) {
  */
 @property (nonatomic, readonly) NSTimeInterval timeIntervalCrashInLastSessionOccurred;
 
+/**
+ * Sends a crash report without a strack trace.
+ *
+ * Allows to report non-fatal conditions that require special attention but do not lead to an immediate crash.
+ * Besides the lack of a stack trace, all the usual information is attached to the report. It will therefore
+ * appear in the Hockey dashboard like a usual crash.
+ *
+ * @param message The text that is shown as the reason of the "crash".
+ */
+- (void)sendNonFatalReportWithMessage:(NSString *)message;
 
 ///-----------------------------------------------------------------------------
 /// @name Helper

--- a/Classes/BITCrashManager.m
+++ b/Classes/BITCrashManager.m
@@ -1299,6 +1299,26 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const BITCr
  *  Creates a fake crash report because the app was killed while being in foreground
  */
 - (void)createCrashReportForAppKill {
+  NSMutableString *info = [NSMutableString string];
+
+  [info appendString:@"The application did not terminate cleanly but no crash occured."];
+  if (self.didReceiveMemoryWarningInLastSession) {
+    [info appendString:@" The app received at least one Low Memory Warning."];
+  }
+
+  self.lastSessionCrashDetails = [self createFakeCrashReportWithApplicationSpecificInformation:info];
+}
+
+- (void)sendNonFatalReportWithMessage:(NSString *)message
+{
+  [self createFakeCrashReportWithApplicationSpecificInformation:message];
+  [self triggerDelayedProcessing];
+}
+
+/**
+ *  Creates a fake crash report
+ */
+- (BITCrashDetails *)createFakeCrashReportWithApplicationSpecificInformation:(NSString *)applicationSpecificInformation {
   NSString *fakeReportUUID = bit_UUID();
   NSString *fakeReporterKey = bit_appAnonID(NO) ?: @"???";
   
@@ -1306,7 +1326,7 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const BITCr
 
   NSString *fakeReportAppVersion = [[NSUserDefaults standardUserDefaults] objectForKey:kBITAppVersion];
   if (!fakeReportAppVersion)
-    return;
+    return nil;
   
   NSString *fakeReportOSVersion = [[NSUserDefaults standardUserDefaults] objectForKey:kBITAppOSVersion] ?: [[UIDevice currentDevice] systemVersion];
   
@@ -1351,10 +1371,7 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const BITCr
   [fakeReportString appendString:@"Exception Codes: 00000020 at 0x8badf00d\n"];
   [fakeReportString appendString:@"\n"];
   [fakeReportString appendString:@"Application Specific Information:\n"];
-  [fakeReportString appendString:@"The application did not terminate cleanly but no crash occured."];
-  if (self.didReceiveMemoryWarningInLastSession) {
-    [fakeReportString appendString:@" The app received at least one Low Memory Warning."];
-  }
+  [fakeReportString appendString:applicationSpecificInformation];
   [fakeReportString appendString:@"\n\n"];
   
   NSString *fakeReportFilename = [NSString stringWithFormat: @"%.0f", [NSDate timeIntervalSinceReferenceDate]];
@@ -1371,20 +1388,6 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const BITCr
   [rootObj setObject:fakeReportDeviceModel forKey:kBITFakeCrashDeviceModel];
   [rootObj setObject:fakeReportAppUUIDs forKey:kBITFakeCrashAppBinaryUUID];
   [rootObj setObject:fakeReportString forKey:kBITFakeCrashReport];
-  
-  self.lastSessionCrashDetails = [[BITCrashDetails alloc] initWithIncidentIdentifier:fakeReportUUID
-                                                                     reporterKey:fakeReporterKey
-                                                                          signal:fakeSignalName
-                                                                   exceptionName:nil
-                                                                 exceptionReason:nil
-                                                                    appStartTime:nil
-                                                                       crashTime:nil
-                                                                       osVersion:fakeReportOSVersion
-                                                                         osBuild:fakeReportOSBuild
-                                                                      appVersion:fakeReportAppMarketingVersion
-                                                                        appBuild:fakeReportAppVersion
-                                                            appProcessIdentifier:[[NSProcessInfo processInfo] processIdentifier]
-                              ];
 
   NSData *plist = [NSPropertyListSerialization dataWithPropertyList:(id)rootObj
                                                              format:NSPropertyListBinaryFormat_v1_0
@@ -1397,6 +1400,20 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const BITCr
   } else {
     BITHockeyLogError(@"ERROR: Writing fake crash report. %@", [error description]);
   }
+
+  return [[BITCrashDetails alloc] initWithIncidentIdentifier:fakeReportUUID
+                                                 reporterKey:fakeReporterKey
+                                                      signal:fakeSignalName
+                                               exceptionName:nil
+                                             exceptionReason:nil
+                                                appStartTime:nil
+                                                   crashTime:nil
+                                                   osVersion:fakeReportOSVersion
+                                                     osBuild:fakeReportOSBuild
+                                                  appVersion:fakeReportAppMarketingVersion
+                                                    appBuild:fakeReportAppVersion
+                                        appProcessIdentifier:[[NSProcessInfo processInfo] processIdentifier]
+          ];
 }
 
 /**


### PR DESCRIPTION
I didn't dig into the project too much, so I'm not sure if I missed something here. But in a short test, this worked flawlessly. Would be nice if you would consider this addition. 

I read [a thread](https://support.hockeyapp.net/discussions/problems/55184-what-are-the-reaons-why-the-ios-sdk-doesnt-support-sending-handled-exceptions) about this topic and it seems that this is planned on your side anyway. In my opinion, it would be very valuable.