### PR TITLE
Disable metrics in HockeySDKCrashOnlyConfig.h

### DIFF
--- a/Support/HockeySDKCrashOnlyConfig.h
+++ b/Support/HockeySDKCrashOnlyConfig.h
@@ -93,7 +93,7 @@
  * _Default_: Enabled
  */
 #ifndef HOCKEYSDK_FEATURE_METRICS
-#    define HOCKEYSDK_FEATURE_METRICS 1
+#    define HOCKEYSDK_FEATURE_METRICS 0
 #endif /* HOCKEYSDK_FEATURE_METRICS */
 
 #endif /* HockeySDK_HockeySDKFeatureConfig_h */


### PR DESCRIPTION
#416 disabled metrics in crashonly.xcconfig (71de3c14f76086d22cf4d68c12ea4d8b53a1f0f0), but the header was never updated.