### PR TITLE
Disable code coverage for Carthage to work with Xcode 9

### DIFF
--- a/Support/HockeySDKBase.xcconfig
+++ b/Support/HockeySDKBase.xcconfig
@@ -68,3 +68,5 @@ CLANG_ANALYZER_NONNULL = YES
 // Enable warnings-are-errors for all modes. Don't do this just yet.
 GCC_TREAT_WARNINGS_AS_ERRORS = NO
 
+// Code coverage has to be disabled for Carthage to work with Xcode 9.
+CLANG_ENABLE_CODE_COVERAGE = NO


### PR DESCRIPTION
Fixes #467