### PR TITLE
Fix/metrics manager trackevent threadsafe

### DIFF
--- a/Classes/BITChannel.h
+++ b/Classes/BITChannel.h
@@ -11,7 +11,10 @@
 #import "HockeySDKNullability.h"
 NS_ASSUME_NONNULL_BEGIN
 
-FOUNDATION_EXPORT char *BITSafeJsonEventsString;
+/**
+ * Buffer of telemtry events, will be written to disk. Make sure the buffer is used in a threadsafe way.
+ */
+FOUNDATION_EXPORT char *_Nullable BITTelemetryEventBuffer;
 
 /**
  *  Items get queued before they are persisted and sent out as a batch. This class managed the queue, and forwards the batch

--- a/Classes/BITChannel.m
+++ b/Classes/BITChannel.m
@@ -3,6 +3,7 @@
 #if HOCKEYSDK_FEATURE_METRICS
 
 #import "HockeySDKPrivate.h"
+#import "BITHockeyManager.h"
 #import "BITChannelPrivate.h"
 #import "BITHockeyHelper.h"
 #import "BITTelemetryContext.h"
@@ -12,9 +13,11 @@
 #import "BITData.h"
 #import "BITDevice.h"
 #import "BITPersistencePrivate.h"
+#import <libkern/OSAtomic.h>
+
 
 static char *const BITDataItemsOperationsQueue = "net.hockeyapp.senderQueue";
-char *BITSafeJsonEventsString;
+char *BITTelemetryEventBuffer;
 
 NSString *const BITChannelBlockedNotification = @"BITChannelBlockedNotification";
 
@@ -42,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init {
   if ((self = [super init])) {
-    bit_resetSafeJsonStream(&BITSafeJsonEventsString);
+    bit_resetEventBuffer(&BITTelemetryEventBuffer);
     _dataItemCount = 0;
     if (bit_isDebuggerAttached()) {
       _maxBatchSize = BITDebugMaxBatchSize;
@@ -80,7 +83,6 @@ NS_ASSUME_NONNULL_BEGIN
     void (^notificationBlock)(NSNotification *note) = ^(NSNotification __unused *note) {
       typeof(self) strongSelf = weakSelf;
       if ([strongSelf timerIsRunning]) {
-        [strongSelf persistDataItemQueue];
         
         /**
          * From the documentation for applicationDidEnterBackground:
@@ -93,12 +95,15 @@ NS_ASSUME_NONNULL_BEGIN
           [sharedApplication endBackgroundTask:_backgroundTask];
           _backgroundTask = UIBackgroundTaskInvalid;
         }];
+        
+        // Do background work that will be done in it's own async queue.
+        [strongSelf persistDataItemQueue:&BITTelemetryEventBuffer];
       }
     };
     self.appDidEnterBackgroundObserver = [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidEnterBackgroundNotification
-                                                                                       object:nil
-                                                                                        queue:NSOperationQueue.mainQueue
-                                                                                   usingBlock:notificationBlock];
+                                                                                           object:nil
+                                                                                            queue:NSOperationQueue.mainQueue
+                                                                                       usingBlock:notificationBlock];
   }
 }
 
@@ -123,22 +128,40 @@ NS_ASSUME_NONNULL_BEGIN
   return self.channelBlocked;
 }
 
-- (void)persistDataItemQueue {
+- (void)persistDataItemQueue:(char **)string {
   [self invalidateTimer];
-  if (!BITSafeJsonEventsString || strlen(BITSafeJsonEventsString) == 0) {
+  char* jsonStream = NULL;
+  char *newEmptyString = NULL;
+  do {
+    jsonStream = *string;
+    newEmptyString = strdup("");
+    
+    // Reset both, the async-signal-safe buffer and item counter. Swaps jsonStream and BITSafeJsonEventsString.
+    if (OSAtomicCompareAndSwapPtr(jsonStream, newEmptyString, (void*)string)) {
+      self.dataItemCount = 0;
+      break;
+    }
+  } while(true);
+  
+  if (!jsonStream || strlen(jsonStream) == 0) {
+    free(jsonStream);
     return;
   }
   
-  NSData *bundle = [NSData dataWithBytes:BITSafeJsonEventsString length:strlen(BITSafeJsonEventsString)];
+  NSData *bundle = [NSData dataWithBytes:jsonStream length:strlen(jsonStream)];
   [self.persistence persistBundle:bundle];
+  
+  free(jsonStream);
   
   // Reset both, the async-signal-safe and item counter.
   [self resetQueue];
 }
 
 - (void)resetQueue {
-  bit_resetSafeJsonStream(&BITSafeJsonEventsString);
-  self.dataItemCount = 0;
+  @synchronized (self) {
+    bit_resetEventBuffer(&BITTelemetryEventBuffer);
+    self.dataItemCount = 0;
+  }
 }
 
 #pragma mark - Adding to queue
@@ -146,16 +169,20 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)enqueueTelemetryItem:(BITTelemetryData *)item {
   
   if (!item) {
-    // Case 1: Item is nil: Do not enqueue item and abort operation
+    
+    // Case 1: Item is nil: Do not enqueue item and abort operation.
     BITHockeyLogWarning(@"WARNING: TelemetryItem was nil.");
     return;
   }
   
+  // first assigning self to weakSelf and then assigning this to strongSelf in the block is not very intuitive, this
+  // blog post explains it very well: https://dhoerl.wordpress.com/2013/04/23/i-finally-figured-out-weakself-and-strongself/
   __weak typeof(self) weakSelf = self;
   dispatch_async(self.dataItemsOperations, ^{
-    typeof(self) strongSelf = weakSelf;
     
+    typeof(self) strongSelf = weakSelf;
     if (strongSelf.isQueueBusy) {
+      
       // Case 2: Channel is in blocked state: Trigger sender, start timer to check after again after a while and abort operation.
       BITHockeyLogDebug(@"INFO: The channel is saturated. %@ was dropped.", item.debugDescription);
       if (![strongSelf timerIsRunning]) {
@@ -164,15 +191,15 @@ NS_ASSUME_NONNULL_BEGIN
       return;
     }
     
-    // Enqueue item
-    NSDictionary *dict = [self dictionaryForTelemetryData:item];
-    [strongSelf appendDictionaryToJsonStream:dict];
-    
-    if (strongSelf.dataItemCount >= self.maxBatchSize) {
-      // Case 3: Max batch count has been reached, so write queue to disk and delete all items.
-      [strongSelf persistDataItemQueue];
+    // Enqueue item.
+    NSDictionary *dict = [strongSelf dictionaryForTelemetryData:item];
+    [strongSelf appendDictionaryToEventBuffer:dict];
+    if (strongSelf.dataItemCount >= strongSelf.maxBatchSize) {
       
-    } else if (strongSelf.dataItemCount == 1) {
+      // Case 3: Max batch count has been reached, so write queue to disk and delete all items.
+      [strongSelf persistDataItemQueue:&BITTelemetryEventBuffer];
+    } else if (strongSelf.dataItemCount > 0) {
+      
       // Case 4: It is the first item, let's start the timer.
       if (![strongSelf timerIsRunning]) {
         [strongSelf startTimer];
@@ -223,39 +250,74 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark JSON Stream
 
-- (void)appendDictionaryToJsonStream:(NSDictionary *)dictionary {
+- (void)appendDictionaryToEventBuffer:(NSDictionary *)dictionary {
   if (dictionary) {
     NSString *string = [self serializeDictionaryToJSONString:dictionary];
     
     // Since we can't persist every event right away, we write it to a simple C string.
     // This can then be written to disk by a signal handler in case of a crash.
-    bit_appendStringToSafeJsonStream(string, &(BITSafeJsonEventsString));
-    self.dataItemCount += 1;
+    @synchronized (self) {
+      bit_appendStringToEventBuffer(string, &BITTelemetryEventBuffer);
+      self.dataItemCount += 1;
+    }
   }
 }
 
-void bit_appendStringToSafeJsonStream(NSString *string, char **jsonString) {
-  if (jsonString == NULL) { return; }
-  
-  if (!string) { return; }
-  
-  if (*jsonString == NULL || strlen(*jsonString) == 0) {
-    bit_resetSafeJsonStream(jsonString);
+void bit_appendStringToEventBuffer(NSString *string, char **eventBuffer) {
+  if (eventBuffer == NULL) {
+    return;
   }
   
-  if (string.length == 0) { return; }
+  if (!string) {
+    return;
+  }
   
-  char *new_string = NULL;
-  // Concatenate old string with new JSON string and add a comma.
-  asprintf(&new_string, "%s%.*s\n", *jsonString, (int)MIN(string.length, (NSUInteger)INT_MAX), string.UTF8String);
-  free(*jsonString);
-  *jsonString = new_string;
+  if (*eventBuffer == NULL || strlen(*eventBuffer) == 0) {
+    bit_resetEventBuffer(eventBuffer);
+  }
+  
+  if (string.length == 0) {
+    return;
+  }
+  
+  char *newBuffer = NULL;
+  char *previousBuffer = NULL;
+  do {
+    previousBuffer = *eventBuffer;
+    
+    // Concatenate old string with new JSON string and add a comma.
+    asprintf(&newBuffer, "%s%.*s\n", previousBuffer, (int)MIN(string.length, (NSUInteger)INT_MAX), string.UTF8String);
+    
+    // Compare newBuffer and previousBuffer. If they point to the same address, we are safe to use them.
+    if (OSAtomicCompareAndSwapPtr(previousBuffer, newBuffer, (void*)eventBuffer)) {
+      
+      // *jsonString has not been changed, we remove a previous value.
+      free(previousBuffer);
+      // TODO should we increase the counter here?
+      return;
+    } else {
+      
+      // newBuffer has been changed by anothe thread.
+      free(newBuffer);
+    }
+  } while (true);
 }
 
-void bit_resetSafeJsonStream(char **string) {
-  if (!string) { return; }
-  free(*string);
-  *string = strdup("");
+void bit_resetEventBuffer(char **eventBuffer) {
+  if (!eventBuffer) { return; }
+  
+  char *newEmptyString = NULL;
+  char *prevString = NULL;
+  do {
+    prevString = *eventBuffer;
+    newEmptyString = strdup("");
+    
+    // Compare pointers to strings to make sure we are still threadsafe!
+    if (OSAtomicCompareAndSwapPtr(prevString, newEmptyString, (void*)eventBuffer)) {
+      free(prevString);
+      return;
+    }
+  } while(true);
 }
 
 #pragma mark - Batching
@@ -279,28 +341,26 @@ void bit_resetSafeJsonStream(char **string) {
 }
 
 - (void)startTimer {
-  // Reset timer, if it is already running
+  
+  // Reset timer, if it is already running.
   if ([self timerIsRunning]) {
     [self invalidateTimer];
   }
   
   self.timerSource = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, self.dataItemsOperations);
   dispatch_source_set_timer((dispatch_source_t)self.timerSource, dispatch_walltime(NULL, NSEC_PER_SEC * self.batchInterval), 1ull * NSEC_PER_SEC, 1ull * NSEC_PER_SEC);
-  
   __weak typeof(self) weakSelf = self;
   dispatch_source_set_event_handler((dispatch_source_t)self.timerSource, ^{
     typeof(self) strongSelf = weakSelf;
-    
-    if(strongSelf) {
+    if (strongSelf) {
       if (strongSelf.dataItemCount > 0) {
-        [strongSelf persistDataItemQueue];
+        [strongSelf persistDataItemQueue:&BITTelemetryEventBuffer];
       } else {
         strongSelf.channelBlocked = NO;
       }
       [strongSelf invalidateTimer];
     }
   });
-  
   dispatch_resume((dispatch_source_t)self.timerSource);
 }
 

--- a/Classes/BITChannel.m
+++ b/Classes/BITChannel.m
@@ -132,7 +132,7 @@ NS_ASSUME_NONNULL_BEGIN
   [self invalidateTimer];
   
   // Make sure string (which points to BITTelemetryEventBuffer) is not changed.
-  char* previousBuffer = NULL;
+  char *previousBuffer = NULL;
   char *newEmptyString = NULL;
   do {
     newEmptyString = strdup("");

--- a/Classes/BITChannelPrivate.h
+++ b/Classes/BITChannelPrivate.h
@@ -70,28 +70,28 @@ FOUNDATION_EXPORT NSString *const BITChannelBlockedNotification;
 /**
  *  Manually trigger the BITChannel to persist all items currently in its data item queue.
  */
-- (void)persistDataItemQueue;
+- (void)persistDataItemQueue:(char *_Nullable*_Nullable)string;
 
 /**
  *  Adds the specified dictionary to the JSON Stream string.
  *
  *  @param dictionary the dictionary object which is to be added to the JSON Stream queue string.
  */
-- (void)appendDictionaryToJsonStream:(NSDictionary *)dictionary;
+- (void)appendDictionaryToEventBuffer:(NSDictionary *)dictionary;
 
 /**
  *  A C function that serializes a given dictionary to JSON and appends it to a char string
  *
  *  @param string The C string which the dictionary's JSON representation will be appended to.
  */
-void bit_appendStringToSafeJsonStream(NSString *string, char *__nonnull*__nonnull jsonStream);
+void bit_appendStringToEventBuffer(NSString *string, char *__nonnull*__nonnull eventBuffer);
 
 /**
- *  Reset BITSafeJsonEventsString so we can start appending JSON dictionaries.
+ *  Reset the event buffer so we can start appending JSON dictionaries.
  *
- *  @param jsonStream The string that will be reset.
+ *  @param eventBuffer The string that will be reset.
  */
-void bit_resetSafeJsonStream(char *__nonnull*__nonnull jsonStream);
+void bit_resetEventBuffer(char *__nonnull*__nonnull eventBuffer);
 
 /**
  *  A method which indicates whether the telemetry pipeline is busy and no new data should be enqueued.

--- a/Classes/BITChannelPrivate.h
+++ b/Classes/BITChannelPrivate.h
@@ -70,7 +70,7 @@ FOUNDATION_EXPORT NSString *const BITChannelBlockedNotification;
 /**
  *  Manually trigger the BITChannel to persist all items currently in its data item queue.
  */
-- (void)persistDataItemQueue:(char *_Nullable*_Nullable)string;
+- (void)persistDataItemQueue:(char *_Nullable*_Nullable)eventBuffer;
 
 /**
  *  Adds the specified dictionary to the JSON Stream string.

--- a/Classes/BITCrashManager.m
+++ b/Classes/BITCrashManager.m
@@ -107,7 +107,7 @@ static BITCrashManagerCallbacks bitCrashCallbacks = {
 static void bit_save_events_callback(siginfo_t __unused *info, ucontext_t __unused *uap, void __unused *context) {
   
   // Do not flush metrics queue if queue is empty (metrics module disabled) to not freeze the app
-  if (!BITSafeJsonEventsString) {
+  if (!BITTelemetryEventBuffer) {
     return;
   }
   
@@ -117,10 +117,10 @@ static void bit_save_events_callback(siginfo_t __unused *info, ucontext_t __unus
     return;
   }
   
-  size_t len = strlen(BITSafeJsonEventsString);
+  size_t len = strlen(BITTelemetryEventBuffer);
   if (len > 0) {
     // Simply write the whole string to disk
-    write(fd, BITSafeJsonEventsString, len);
+    write(fd, BITTelemetryEventBuffer, len);
   }
   close(fd);
 }

--- a/Support/HockeySDKTests/BITChannelTests.m
+++ b/Support/HockeySDKTests/BITChannelTests.m
@@ -120,24 +120,4 @@
   XCTAssertEqual(strcmp(BITTelemetryEventBuffer,""), 0);
 }
 
-- (void) testBITEventBufferThreadSafety {
-  int count = 1000;
-  XCTestExpectation *expectation1 = [[XCTestExpectation alloc] initWithDescription:@"append"];
-  XCTestExpectation *expectation2 = [[XCTestExpectation alloc] initWithDescription:@"reset"];
-  dispatch_async(dispatch_queue_create("queue1", DISPATCH_QUEUE_SERIAL), ^{
-    for(int i = 0; i < count; i++) {
-      bit_appendStringToEventBuffer([NSString stringWithFormat:@"%d", i], &BITTelemetryEventBuffer);
-    }
-    [expectation1 fulfill];
-  });
-  dispatch_async(dispatch_queue_create("queue2", DISPATCH_QUEUE_SERIAL), ^{
-    for(int i = 0; i < count; i++) {
-      bit_resetEventBuffer(&BITTelemetryEventBuffer);
-    }
-    [expectation2 fulfill];
-  });
-  [self waitForExpectations:@[expectation1, expectation2] timeout: 10];
-  XCTAssertTrue(true);
-}
-
 @end

--- a/Support/HockeySDKTests/BITChannelTests.m
+++ b/Support/HockeySDKTests/BITChannelTests.m
@@ -27,7 +27,7 @@
   BITTelemetryContext *mockContext = mock(BITTelemetryContext.class);
   
   self.sut = [[BITChannel alloc]initWithTelemetryContext:mockContext persistence:self.mockPersistence];
-  bit_resetSafeJsonStream(&BITSafeJsonEventsString);
+  bit_resetEventBuffer(&BITTelemetryEventBuffer);
 }
 
 #pragma mark - Setup Tests
@@ -48,7 +48,7 @@
   
   dispatch_sync(self.sut.dataItemsOperations, ^{
     assertThatUnsignedInteger(self.sut.dataItemCount, equalToUnsignedInteger(1));
-    XCTAssertTrue(strlen(BITSafeJsonEventsString) > 0);
+    XCTAssertTrue(strlen(BITTelemetryEventBuffer) > 0);
   });
 }
 
@@ -63,19 +63,19 @@
   [self.sut enqueueTelemetryItem:testData];
   dispatch_sync(self.sut.dataItemsOperations, ^{
     assertThatUnsignedInteger(self.sut.dataItemCount, equalToUnsignedInteger(1));
-    XCTAssertTrue(strlen(BITSafeJsonEventsString) > 0);
+    XCTAssertTrue(strlen(BITTelemetryEventBuffer) > 0);
   });
   
   [self.sut enqueueTelemetryItem:testData];
   dispatch_sync(self.sut.dataItemsOperations, ^{
     assertThatUnsignedInteger(self.sut.dataItemCount, equalToUnsignedInteger(2));
-    XCTAssertTrue(strlen(BITSafeJsonEventsString) > 0);
+    XCTAssertTrue(strlen(BITTelemetryEventBuffer) > 0);
   });
   
   [self.sut enqueueTelemetryItem:testData];
   dispatch_sync(self.sut.dataItemsOperations, ^{
     assertThatUnsignedInteger(self.sut.dataItemCount, equalToUnsignedInteger(0));
-    XCTAssertTrue(strcmp(BITSafeJsonEventsString, "") == 0);
+    XCTAssertTrue(strcmp(BITTelemetryEventBuffer, "") == 0);
   });
 }
 
@@ -84,42 +84,40 @@
 - (void)testAppendStringToSafeJsonStream {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"
-  bit_appendStringToSafeJsonStream(nil, 0);
+  bit_appendStringToEventBuffer(nil, 0);
 #pragma clang diagnostic pop
-  XCTAssertEqual(strcmp(BITSafeJsonEventsString,""), 0);
+  XCTAssertEqual(strcmp(BITTelemetryEventBuffer,""), 0);
   
-//  BITSafeJsonEventsString = NULL;
-  bit_resetSafeJsonStream(&BITSafeJsonEventsString);
+  bit_resetEventBuffer(&BITTelemetryEventBuffer);
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"
-  bit_appendStringToSafeJsonStream(nil, &BITSafeJsonEventsString);
+  bit_appendStringToEventBuffer(nil, &BITTelemetryEventBuffer);
 #pragma clang diagnostic pop
-  XCTAssertEqual(strcmp(BITSafeJsonEventsString,""), 0);
+  XCTAssertEqual(strcmp(BITTelemetryEventBuffer,""), 0);
   
-  bit_appendStringToSafeJsonStream(@"", &BITSafeJsonEventsString);
-  XCTAssertEqual(strcmp(BITSafeJsonEventsString,""), 0);
+  bit_appendStringToEventBuffer(@"", &BITTelemetryEventBuffer);
+  XCTAssertEqual(strcmp(BITTelemetryEventBuffer,""), 0);
   
-  bit_appendStringToSafeJsonStream(@"{\"Key1\":\"Value1\"}", &BITSafeJsonEventsString);
-  XCTAssertEqual(strcmp(BITSafeJsonEventsString,"{\"Key1\":\"Value1\"}\n"), 0);
+  bit_appendStringToEventBuffer(@"{\"Key1\":\"Value1\"}", &BITTelemetryEventBuffer);
+  XCTAssertEqual(strcmp(BITTelemetryEventBuffer,"{\"Key1\":\"Value1\"}\n"), 0);
 }
 
 - (void)testResetSafeJsonStream {
-  bit_resetSafeJsonStream(&BITSafeJsonEventsString);
-  XCTAssertEqual(strcmp(BITSafeJsonEventsString,""), 0);
+  bit_resetEventBuffer(&BITTelemetryEventBuffer);
+  XCTAssertEqual(strcmp(BITTelemetryEventBuffer,""), 0);
   
-//  BITSafeJsonEventsString = NULL;
-  bit_resetSafeJsonStream(&BITSafeJsonEventsString);
+  bit_resetEventBuffer(&BITTelemetryEventBuffer);
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"
-  bit_resetSafeJsonStream(nil);
+  bit_resetEventBuffer(nil);
 #pragma clang diagnostic pop
-  XCTAssertEqual(strcmp(BITSafeJsonEventsString,""), 0);
+  XCTAssertEqual(strcmp(BITTelemetryEventBuffer,""), 0);
   
-  BITSafeJsonEventsString = strdup("test string");
-  bit_resetSafeJsonStream(&BITSafeJsonEventsString);
-  XCTAssertEqual(strcmp(BITSafeJsonEventsString,""), 0);
+  BITTelemetryEventBuffer = strdup("test string");
+  bit_resetEventBuffer(&BITTelemetryEventBuffer);
+  XCTAssertEqual(strcmp(BITTelemetryEventBuffer,""), 0);
 }
 
 @end

--- a/Support/HockeySDKTests/BITChannelTests.m
+++ b/Support/HockeySDKTests/BITChannelTests.m
@@ -81,7 +81,7 @@
 
 #pragma mark - Safe JSON Stream Tests
 
-- (void)testAppendStringToSafeJsonStream {
+- (void)testAppendStringToEventBuffer {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"
   bit_appendStringToEventBuffer(nil, 0);

--- a/Support/HockeySDKTests/BITChannelTests.m
+++ b/Support/HockeySDKTests/BITChannelTests.m
@@ -120,4 +120,24 @@
   XCTAssertEqual(strcmp(BITTelemetryEventBuffer,""), 0);
 }
 
+- (void) testBITEventBufferThreadSafety {
+  int count = 1000;
+  XCTestExpectation *expectation1 = [[XCTestExpectation alloc] initWithDescription:@"append"];
+  XCTestExpectation *expectation2 = [[XCTestExpectation alloc] initWithDescription:@"reset"];
+  dispatch_async(dispatch_queue_create("queue1", DISPATCH_QUEUE_SERIAL), ^{
+    for(int i = 0; i < count; i++) {
+      bit_appendStringToEventBuffer([NSString stringWithFormat:@"%d", i], &BITTelemetryEventBuffer);
+    }
+    [expectation1 fulfill];
+  });
+  dispatch_async(dispatch_queue_create("queue2", DISPATCH_QUEUE_SERIAL), ^{
+    for(int i = 0; i < count; i++) {
+      bit_resetEventBuffer(&BITTelemetryEventBuffer);
+    }
+    [expectation2 fulfill];
+  });
+  [self waitForExpectations:@[expectation1, expectation2] timeout: 10];
+  XCTAssertTrue(true);
+}
+
 @end


### PR DESCRIPTION
Hopefully a more thorough approach to making BITChannel thread-safe.

I'm combining mutexes and atomic compare and swap based on https://github.com/bitstadium/HockeySDK-iOS/pulls and https://github.com/bitstadium/HockeySDK-Mac/pull/106.

From testing, this works great. I'm happy for as many pairs of eyes as possible.