### PR TITLE
Moved creating cached preview items to didSelectAttachmentMethod

### DIFF
--- a/Classes/BITFeedbackListViewController.m
+++ b/Classes/BITFeedbackListViewController.m
@@ -716,6 +716,10 @@
 #pragma mark - ListViewCellDelegate
 
 - (void)listCell:(id) __unused cell didSelectAttachment:(BITFeedbackMessageAttachment *)attachment {
+  if (!self.cachedPreviewItems){
+    [self refreshPreviewItems];
+  }
+  
   QLPreviewController *previewController = [[QLPreviewController alloc] init];
   previewController.dataSource = self;
   
@@ -739,10 +743,6 @@
 }
 
 - (NSInteger)numberOfPreviewItemsInPreviewController:(QLPreviewController *) __unused controller {
-  if (!self.cachedPreviewItems){
-    [self refreshPreviewItems];
-  }
-  
   return self.cachedPreviewItems.count;
 }
 


### PR DESCRIPTION
During first clicking on the attachment in the feedback list, it is not displayed properly as the condition below is not true, and we cannot set current preview index properly:
```
if (self.cachedPreviewItems.count > [self.cachedPreviewItems indexOfObject:attachment]) {
    [previewController setCurrentPreviewItemIndex:[self.cachedPreviewItems indexOfObject:attachment]];
}
```