### PR TITLE
Specify block as void

### DIFF
--- a/Classes/BITChannel.m
+++ b/Classes/BITChannel.m
@@ -221,8 +221,8 @@ NS_ASSUME_NONNULL_BEGIN
     backgroundTask = UIBackgroundTaskInvalid;
   }];
   __block NSUInteger i = 0;
-  __block __weak void (^weakWaitBlock)();
-  void (^waitBlock)();
+  __block __weak void (^weakWaitBlock)(void);
+  void (^waitBlock)(void);
   weakWaitBlock = waitBlock = ^{
     if (i < queues.count) {
       dispatch_queue_t queue = [queues objectAtIndex:i++];


### PR DESCRIPTION
Fixes a warning for missing `void` in block when integrating the SDK as a submodule in Xcode 9.2