### PR TITLE
if available, give info-collecting textFields a content type

### DIFF
--- a/Classes/BITFeedbackUserDataViewController.m
+++ b/Classes/BITFeedbackUserDataViewController.m
@@ -191,9 +191,11 @@
 
     if ([indexPath row] == 0 && [strongManager requireUserName] != BITFeedbackUserDataElementDontShow) {
       textField.placeholder = BITHockeyLocalizedString(@"HockeyFeedbackUserDataNamePlaceHolder");
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
       if (@available(iOS 10.0, *)) {
         textField.textContentType = UITextContentTypeName;
       }
+#endif
       textField.text = self.name;
       if (strongManager.requireUserName == BITFeedbackUserDataElementRequired) {
         textField.accessibilityHint = BITHockeyLocalizedString(@"HockeyAccessibilityHintRequired");
@@ -209,9 +211,11 @@
       [textField becomeFirstResponder];
     } else {
       textField.placeholder = BITHockeyLocalizedString(@"HockeyFeedbackUserDataEmailPlaceholder");
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
       if (@available(iOS 10.0, *)) {
         textField.textContentType = UITextContentTypeEmailAddress;
       }
+#endif
       textField.text = self.email;
       if (strongManager.requireUserEmail == BITFeedbackUserDataElementRequired) {
         textField.accessibilityHint = BITHockeyLocalizedString(@"HockeyAccessibilityHintRequired");

--- a/Classes/BITFeedbackUserDataViewController.m
+++ b/Classes/BITFeedbackUserDataViewController.m
@@ -191,6 +191,9 @@
 
     if ([indexPath row] == 0 && [strongManager requireUserName] != BITFeedbackUserDataElementDontShow) {
       textField.placeholder = BITHockeyLocalizedString(@"HockeyFeedbackUserDataNamePlaceHolder");
+      if (@available(iOS 10.0, *)) {
+        textField.textContentType = UITextContentTypeName;
+      }
       textField.text = self.name;
       if (strongManager.requireUserName == BITFeedbackUserDataElementRequired) {
         textField.accessibilityHint = BITHockeyLocalizedString(@"HockeyAccessibilityHintRequired");
@@ -206,6 +209,9 @@
       [textField becomeFirstResponder];
     } else {
       textField.placeholder = BITHockeyLocalizedString(@"HockeyFeedbackUserDataEmailPlaceholder");
+      if (@available(iOS 10.0, *)) {
+        textField.textContentType = UITextContentTypeEmailAddress;
+      }
       textField.text = self.email;
       if (strongManager.requireUserEmail == BITFeedbackUserDataElementRequired) {
         textField.accessibilityHint = BITHockeyLocalizedString(@"HockeyAccessibilityHintRequired");


### PR DESCRIPTION
The idea is to enable 'one-tap' filling of those textfields.
I haven't actually tested this, as I don't think I have HockeySDK included in source-form anywhere right now, and the demo app doesn't seem to show the feedback UI.
Do you have a Demo app that does?